### PR TITLE
Configure Nginx proxy for TLS termination

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,21 @@
 services:
+  proxy:
+    depends_on:
+      - collaboratorium
+    environment:
+      CERTBOT_EMAIL: ${CERTBOT_EMAIL:?}
+      DOMAIN: ${DOMAIN:?}
+      NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx/user_conf.d
+      USE_LOCAL_CA: ${USE_LOCAL_CA}
+    image: jonasal/nginx-certbot:6.0.1-nginx1.29.1
+    ports:
+      - "80:80"
+      - "443:443"
+    restart: unless-stopped
+    volumes:
+      - ./nginx:/etc/nginx/templates
+      - letsencrypt:/etc/letsencrypt
+
   collaboratorium:
     build: .
     image: collaboratorium:latest
@@ -12,3 +29,7 @@ services:
       - ./schema.dbml:/app/schema.dbml:ro
       - ./.env:/app/.env
     restart: unless-stopped
+
+volumes:
+  letsencrypt:
+    driver: local

--- a/env.example
+++ b/env.example
@@ -1,0 +1,3 @@
+CERTBOT_EMAIL=
+DOMAIN=localhost
+USE_LOCAL_CA=1

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,0 +1,29 @@
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name $DOMAIN;
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+
+    location / {
+        gzip on;
+        gzip_proxied any;
+        client_max_body_size 128k;
+        proxy_buffer_size 16k;
+        proxy_buffers 256 16k;
+        proxy_read_timeout 60s;
+        send_timeout 60s;
+        proxy_http_version 1.1;
+
+        proxy_pass http://collaboratorium:8050;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header X-Forwarded-Proto "https";
+        proxy_set_header X-Forwarded-Protocol "";
+        proxy_set_header X-Forwarded-Ssl "";
+    }
+}


### PR DESCRIPTION
Adds nginx-certbot container that will automatically provision TLS certificates and renew them. Requires email and domain name information in the `.env` file as a minimum. `USE_LOCAL_CA` is useful when set to '1', to test locally, but should be '0' in production.