### PR TITLE
Add Dashboard landing page: a feed of your recent work

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,110 @@
+# TODO
+
+Follow-up issues surfaced while building the Dashboard page. These concern
+shared machinery (the generic form builder, the editor modal, app-wide assets)
+rather than the dashboard itself, so they are scoped separately: a change to any
+of them affects Explore and any organisation that adapts this tool from its own
+schema. Each is written to drop straight into a GitHub issue.
+
+---
+
+## A. Activity form: put the required link fields near the top
+
+**Labels:** enhancement, forms
+
+On `activities_form` the required fields are 1st, 11th and 13th in the form.
+The current order is:
+
+    Name*, Summary, Attachments, Location, Start Date, End Date, Tag Groups,
+    Status, Parent Activities, Child Activities, Linked Initiatives*,
+    Linked Contracts, Linked People*
+
+So to fill the three fields you must supply, you scroll past nine optional ones,
+and the two rarely-used self-referential link fields (Parent/Child Activities)
+sit *above* Linked Initiatives. Reordering `elements` in `config.yaml` so the
+required fields lead would markedly cut the effort of recording an activity —
+this is the highest value-per-effort item of the follow-ups.
+
+Kept out of the dashboard change because `activities_form` is the same form
+reached from the graph node tap, the spreadsheet Edit link and the report links,
+and an adopting organisation inherits whatever order ships. It deserves a
+deliberate decision, not a side effect.
+
+**Acceptance:** the fields a user must fill are reachable without scrolling past
+optional ones; verify the form still renders and saves from every entry point
+(dashboard add, graph tap, spreadsheet Edit).
+
+---
+
+## B. Disabled submit button should name the missing fields
+
+**Labels:** enhancement, forms, ux
+
+While required fields are empty the submit button reads
+"Fill Required Fields to Submit" and is disabled, but never says *which* fields —
+and they may be off-screen (see A). A user can be left staring at a disabled
+button with no cue as to what it wants.
+
+Either name the outstanding fields ("Add a name and a linked person to submit")
+or mark the empty required fields visibly. Lives in `form_gen.py`; affects every
+form and predates the dashboard.
+
+**Acceptance:** with a required field empty, the UI states which field is
+outstanding; the button enables the moment the last one is filled.
+
+---
+
+## C. Editor modal is a dead end after a successful save
+
+**Labels:** enhancement, editor, ux
+
+After submitting, the editor modal stays open showing
+"Select a table or click an element to edit." above a success line like
+"✅ Created activities record ID 37". The first line reads like an instruction
+the user failed to follow; the second exposes a raw database id.
+
+On success the editor should either close, or show a plain-language confirmation
+naming what was created and what it was linked to
+("Added *Collaboratorium v0.6.0* to Collaboratorium Prototype").
+
+Shared editor behaviour that has always worked this way, but the dashboard makes
+adding a record the common path, so a rarely-seen rough edge becomes a
+constantly-seen one. Motivated by, but not part of, the dashboard work.
+
+**Acceptance:** after a successful add the user is not left on a modal whose
+primary text implies nothing happened; no raw record id is shown as the result.
+
+---
+
+## D. Bootstrap Icons font does not load
+
+**Labels:** bug, assets
+
+`className="bi bi-*"` icons render as nothing throughout the app — the
+Bootstrap Icons stylesheet/font is not among the external stylesheets. The
+existing "Add Element" button's `bi-plus-circle` has never shown, and it forced
+the new dashboard header buttons to use a literal "+" instead of an icon.
+
+Either add the Bootstrap Icons CSS to `external_stylesheets` (self-hosted under
+`assets/` to match the offline/CSP posture) or remove the dead `bi` classes.
+
+**Acceptance:** either `bi` icons render, or no component references a `bi` class
+that resolves to nothing.
+
+---
+
+## E. No guard against duplicate records
+
+**Labels:** discussion, data-quality
+
+Three activities with the identical name were created in a row with no warning.
+This needs a policy decision before any code: duplicate activity names are
+plausibly legitimate ("Weekly standup", "Site visit"), so a hard uniqueness
+constraint is likely wrong. Options range from doing nothing, through a soft
+"an activity with this name already exists — add anyway?" prompt, to
+per-table configuration of which fields should warn.
+
+Decide the intended behaviour first; it may resolve as won't-fix.
+
+**Acceptance:** a documented decision on whether/when duplicates are flagged,
+and an implementation matching it (which may be "no change").

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -164,3 +164,325 @@ summary:hover {
 #report-container h3 {
     color: #9b51e0;
 }
+
+/* =========================================================
+   Dashboard page
+   Entity colours below are the same hues as the network graph
+   stylesheet in config.yaml, so a chip reads as the node it
+   will become in Explore.
+   ========================================================= */
+:root {
+    --dash-initiative: #ff6900;
+    --dash-activity: #9b51e0;
+    --dash-person: #fcb900;
+}
+
+/* --- top nav: Dashboard | Explore --- */
+.nav-page-btn {
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--idems-text-muted);
+    font-weight: 600;
+    font-size: 0.9rem;
+    padding: 6px 16px;
+    border-radius: 6px;
+}
+.nav-page-btn:hover {
+    background: #ffffff;
+    color: var(--idems-text);
+    border-color: var(--border-color);
+}
+.nav-page-btn.active {
+    background: #ffffff;
+    color: var(--idems-text);
+    border-color: var(--border-color);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+/* --- controls --- */
+.dash-ctrl-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+}
+.dash-toggle {
+    display: inline-flex;
+    background: #f8f9fa;
+    border: 1px solid var(--border-color);
+    border-radius: 7px;
+    padding: 3px;
+    gap: 3px;
+}
+.dash-toggle-btn {
+    background: transparent;
+    border: none;
+    color: var(--idems-text-muted);
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 5px 15px;
+    border-radius: 5px;
+}
+.dash-toggle-btn:hover { color: var(--idems-text); background: rgba(0,0,0,0.03); }
+.dash-toggle-btn.active,
+.dash-toggle-btn.active:hover {
+    background: var(--idems-orange);
+    color: #ffffff;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+.dash-window-pick { width: 165px; font-size: 0.85rem; }
+.dash-spacer { flex: 1; }
+
+/* --- panels --- */
+.dash-stack { display: flex; flex-direction: column; gap: 12px; }
+.dash-panel {
+    background: var(--idems-panel);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+.dash-panel-h {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 11px 15px;
+    border-bottom: 1px solid #e8ecef;
+    font-size: 0.74rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--idems-text-muted);
+}
+.dash-count { font-family: monospace; font-size: 0.72rem; font-weight: 700; }
+.dash-panel-sub {
+    font-size: 0.76rem;
+    color: var(--idems-text-muted);
+    padding: 9px 15px 0;
+    margin: 0;
+}
+.dash-empty {
+    font-size: 0.86rem;
+    color: var(--idems-text-muted);
+    padding: 18px 15px;
+    margin: 0;
+}
+.dash-empty-actions {
+    display: flex;
+    gap: 10px;
+    padding: 0 15px 18px;
+    flex-wrap: wrap;
+}
+.dash-near-more { padding: 10px 15px; }
+
+/* --- admin "view as" control + banner --- */
+#view-as-container { margin-bottom: 12px; }
+.dash-view-as-pick { max-width: 320px; font-size: 0.85rem; }
+.dash-viewas-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(242,139,32,0.10);
+    border: 1px solid var(--idems-orange);
+    border-radius: 7px;
+    padding: 8px 14px;
+    margin-bottom: 12px;
+}
+.dash-viewas-name { font-weight: 700; color: var(--idems-text); font-size: 0.9rem; }
+.dash-viewas-tag {
+    font-family: monospace;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #fff;
+    background: var(--idems-orange);
+    border-radius: 20px;
+    padding: 2px 9px;
+}
+
+/* --- chips and faces --- */
+.dash-chip {
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.67rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    padding: 2px 8px;
+    border-radius: 20px;
+    white-space: nowrap;
+}
+.dash-chip::before {
+    content: "";
+    width: 7px;
+    height: 7px;
+    border-radius: 2px;
+    background: currentColor;
+    margin-right: 5px;
+}
+.dash-chip-initiative { color: var(--dash-initiative); background: rgba(255,105,0,0.13); }
+.dash-chip-activity { color: var(--dash-activity); background: rgba(155,81,224,0.13); }
+.dash-avatar {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--dash-person);
+    color: #4a3c00;
+    font-size: 0.58rem;
+    font-weight: 800;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: none;
+}
+.dash-avatar-none {
+    background: #e9ecef;
+    color: var(--idems-text-muted);
+    font-weight: 600;
+}
+.dash-ts, .dash-verb {
+    font-family: monospace;
+    font-size: 0.72rem;
+    color: var(--idems-text-muted);
+    white-space: nowrap;
+}
+
+/* --- initiative group --- */
+.dash-repo { padding: 13px 15px; border-bottom: 1px solid #e8ecef; }
+.dash-repo:last-child { border-bottom: 0; }
+.dash-repo-h { display: flex; align-items: center; gap: 9px; margin-bottom: 3px; flex-wrap: wrap; }
+.dash-repo-sub { font-size: 0.77rem; color: var(--idems-text-muted); margin: 0 0 9px; }
+.dash-entity-link {
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: var(--idems-text);
+    text-decoration: none;
+    cursor: pointer;
+}
+.dash-entity-link:hover { color: var(--idems-orange); text-decoration: underline; }
+.dash-ev-list {
+    border-left: 2px solid var(--border-color);
+    margin-left: 4px;
+    padding-left: 13px;
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+}
+.dash-ev { display: flex; align-items: center; gap: 8px; font-size: 0.82rem; }
+.dash-ev-name { color: var(--idems-text); font-weight: 600; font-size: 0.85rem; }
+
+/* --- rail items --- */
+.dash-item { padding: 11px 15px; border-bottom: 1px solid #e8ecef; }
+.dash-item:last-child { border-bottom: 0; }
+.dash-item-n { margin: 0 0 4px; }
+.dash-item-m { display: flex; align-items: center; gap: 7px; font-size: 0.76rem; color: var(--idems-text-muted); flex-wrap: wrap; }
+.dash-invite { background: rgba(242,139,32,0.06); border-left: 2px solid var(--idems-orange); }
+
+/* --- touching your work --- */
+.dash-touch { padding: 12px 15px; border-bottom: 1px solid #e8ecef; }
+.dash-touch:last-child { border-bottom: 0; }
+.dash-touch-h { display: flex; align-items: center; gap: 8px; margin-bottom: 5px; flex-wrap: wrap; }
+.dash-touch-why { display: flex; align-items: center; gap: 6px; font-size: 0.78rem; color: var(--idems-text-muted); }
+.dash-touch-why .dash-entity-link { font-size: 0.78rem; }
+
+/* --- small buttons --- */
+.dash-mini {
+    background: none;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--idems-text);
+    padding: 3px 9px;
+}
+.dash-mini:hover { background: #f8f9fa; color: var(--idems-text); border-color: var(--idems-text-muted); }
+.dash-mini-go { border-color: var(--idems-orange); color: var(--idems-orange-hover); }
+.dash-mini-go:hover { background: var(--idems-orange); color: #ffffff; border-color: var(--idems-orange); }
+.dash-hide-x {
+    background: none;
+    border: none;
+    color: var(--idems-text-muted);
+    font-size: 0.8rem;
+    padding: 0 2px;
+    line-height: 1;
+}
+.dash-hide-x:hover { color: var(--idems-text); background: none; }
+.dash-hidden-chip {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    background: var(--idems-panel);
+    border: 1px dashed var(--border-color);
+    border-radius: 7px;
+    padding: 9px 14px;
+    font-size: 0.8rem;
+    color: var(--idems-text-muted);
+}
+
+/* --- detail card (read-only inspector) --- */
+.dash-card-h { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.dash-card-t { font-size: 1.15rem; font-weight: 600; color: var(--idems-text); }
+.dash-card-footer { display: flex; align-items: center; width: 100%; }
+.dash-card-sec {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--idems-text-muted);
+    margin: 18px 0 8px;
+}
+.dash-facts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 10px 18px;
+    padding: 4px 0 6px;
+}
+.dash-fact { display: flex; flex-direction: column; gap: 1px; }
+.dash-fact-k {
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--idems-text-muted);
+}
+.dash-fact-v { font-size: 0.9rem; color: var(--idems-text); }
+.dash-prose {
+    font-size: 0.9rem;
+    color: var(--idems-text);
+    background: #f8f9fa;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 12px 14px;
+    margin-top: 12px;
+}
+.dash-prose p:last-child { margin-bottom: 0; }
+.dash-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 12px; }
+.dash-tag {
+    font-size: 0.76rem;
+    background: rgba(100,155,163,0.14);
+    color: #3d6a70;
+    border-radius: 20px;
+    padding: 3px 10px;
+}
+.dash-tag-k { font-weight: 700; }
+.dash-linked { display: flex; flex-direction: column; }
+.dash-linked-row {
+    padding: 7px 10px;
+    border: 1px solid var(--border-color);
+    border-bottom: 0;
+    font-size: 0.86rem;
+}
+.dash-linked-row:first-child { border-radius: 6px 6px 0 0; }
+.dash-linked-row:last-child { border-bottom: 1px solid var(--border-color); border-radius: 0 0 6px 6px; }
+.dash-linked-row:only-child { border-radius: 6px; }
+.dash-linked-row:hover { background: #f8f9fa; }
+.dash-people { display: flex; flex-wrap: wrap; gap: 8px; }
+.dash-person {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: 1px solid var(--border-color);
+    border-radius: 20px;
+    padding: 3px 10px 3px 3px;
+}
+.dash-person-n { font-size: 0.8rem; color: var(--idems-text); }

--- a/collaboratorium/dashboard_data.py
+++ b/collaboratorium/dashboard_data.py
@@ -426,9 +426,13 @@ def format_tags(raw, defs):
         key_values = defs.get(str(group_id), {})
         for element_key, element_val in elements.items():
             cfg = key_values.get(element_key, {})
+            if not isinstance(cfg, dict):
+                cfg = {}
             label = cfg.get("label") or element_key.replace("_", " ").title()
             list_name = cfg.get("list_name")
             options = cfg.get(list_name, {}) if list_name else {}
+            if not isinstance(options, dict):
+                options = {}
             vals = element_val if isinstance(element_val, list) else [element_val]
             text = ", ".join(
                 str(options.get(v, str(v).replace("_", " ").title()))

--- a/collaboratorium/dashboard_data.py
+++ b/collaboratorium/dashboard_data.py
@@ -204,10 +204,18 @@ def recently_updated(person_id, window_days, scope="mine", limit=25):
                     continue
                 i["activity_count"] = len(evs)
                 i["involved_only"] = True
+                # The sort and header date must track the activities actually
+                # shown, not the global latest touch. Otherwise someone else's
+                # later work floats an initiative you only contribute to up the
+                # feed under a date that has nothing to do with you.
+                i["last_touched"] = max(e["timestamp"] for e in evs)
             else:
                 i["involved_only"] = False
             i["events"] = evs[:5]
             result.append(i)
+        # last_touched was rewritten for involved-only rows, so re-establish the
+        # newest-first order the SQL gave us (ISO timestamps sort lexically).
+        result.sort(key=lambda r: r["last_touched"], reverse=True)
         return result
     finally:
         conn.close()

--- a/collaboratorium/dashboard_data.py
+++ b/collaboratorium/dashboard_data.py
@@ -1,0 +1,643 @@
+"""
+dashboard_data.py
+Read-only queries for the Dashboard page.
+
+Deliberately not schema-generic: the dashboard is a fixed projection over
+initiatives, activities and their link tables, so the queries are written by
+hand rather than driven by config. Nothing here writes to the database.
+
+All entity tables are append-only and versioned by (id, version); "latest"
+below always means the highest version of a given id.
+"""
+import json
+from datetime import datetime, timedelta
+
+from db import db_connect
+
+# Rows whose status is 'deleted' are tombstones and never appear on the page.
+_LIVE = "status IS NOT 'deleted'"
+
+
+def _latest(table, alias):
+    """SQL fragment restricting `alias` to the newest version of each id."""
+    return (
+        f"{alias}.version = (SELECT MAX(v.version) FROM {table} v "
+        f"WHERE v.id = {alias}.id)"
+    )
+
+
+def _cutoff_iso(window_days):
+    return (datetime.now() - timedelta(days=window_days)).isoformat()
+
+
+def _rows(cur):
+    cols = [c[0] for c in cur.description]
+    return [dict(zip(cols, r)) for r in cur.fetchall()]
+
+
+# ---------------------------------------------------------
+# "Mine"
+# ---------------------------------------------------------
+# An initiative is Mine if any of:
+#   - I am the responsible person
+#   - I am linked to one of its activities
+#   - I created it AND nobody is responsible for it (orphan fallback)
+_MINE_INITIATIVE_IDS = f"""
+SELECT i.id FROM initiatives i
+WHERE {_latest('initiatives', 'i')} AND i.{_LIVE}
+  AND (
+    i.responsible_person = :me
+    OR i.id IN (
+      SELECT ail.initiative_id FROM activity_initiative_links ail
+      JOIN activity_people_links apl ON apl.activity_id = ail.activity_id
+      WHERE apl.person_id = :me AND ail.{_LIVE} AND apl.{_LIVE}
+    )
+    OR (i.created_by = :me AND i.responsible_person IS NULL)
+  )
+"""
+
+_MY_ACTIVITY_IDS = f"""
+SELECT apl.activity_id FROM activity_people_links apl
+WHERE apl.person_id = :me AND apl.{_LIVE}
+"""
+
+
+def _initiative_scope_clause(scope):
+    """Restrict initiatives to Mine, or everything."""
+    if scope == "mine":
+        return f"AND i.id IN ({_MINE_INITIATIVE_IDS})"
+    return ""
+
+
+# ---------------------------------------------------------
+# Section 1 — Recently updated
+# ---------------------------------------------------------
+def recently_updated(person_id, window_days, scope="mine", limit=25):
+    """
+    Initiatives touched inside the window, each with the activity events that
+    touched it. An initiative counts as touched if it was itself written, or
+    an activity linked to it was written or newly linked.
+
+    Returns [{id, name, responsible_person, responsible_name, activity_count,
+              last_touched, events: [...]}] newest first.
+    """
+    if scope == "mine" and not person_id:
+        return []
+
+    cutoff = _cutoff_iso(window_days)
+    conn = db_connect()
+    cur = conn.cursor()
+    try:
+        # Candidate initiatives: touched directly, or via a linked activity.
+        cur.execute(
+            f"""
+            WITH touched AS (
+              SELECT i.id AS initiative_id, i.timestamp AS ts
+              FROM initiatives i
+              WHERE {_latest('initiatives', 'i')} AND i.{_LIVE}
+                AND i.timestamp >= :cutoff
+                {_initiative_scope_clause(scope)}
+
+              UNION
+
+              SELECT ail.initiative_id, a.timestamp AS ts
+              FROM activity_initiative_links ail
+              JOIN activities a ON a.id = ail.activity_id
+              JOIN initiatives i ON i.id = ail.initiative_id
+              WHERE ail.{_LIVE} AND a.{_LIVE}
+                AND {_latest('initiatives', 'i')} AND i.{_LIVE}
+                AND a.timestamp >= :cutoff
+                {_initiative_scope_clause(scope)}
+
+              UNION
+
+              SELECT ail.initiative_id, ail.timestamp AS ts
+              FROM activity_initiative_links ail
+              JOIN initiatives i ON i.id = ail.initiative_id
+              WHERE ail.{_LIVE}
+                AND {_latest('initiatives', 'i')} AND i.{_LIVE}
+                AND ail.timestamp >= :cutoff
+                {_initiative_scope_clause(scope)}
+            )
+            SELECT i.id,
+                   i.name,
+                   i.responsible_person,
+                   i.created_by,
+                   p.name AS responsible_name,
+                   MAX(t.ts) AS last_touched,
+                   (SELECT COUNT(DISTINCT l.activity_id)
+                      FROM activity_initiative_links l
+                     WHERE l.initiative_id = i.id AND l.{_LIVE}) AS activity_count
+            FROM touched t
+            JOIN initiatives i ON i.id = t.initiative_id
+            LEFT JOIN people p
+              ON p.id = i.responsible_person AND {_latest('people', 'p')}
+            WHERE {_latest('initiatives', 'i')} AND i.{_LIVE}
+            GROUP BY i.id
+            -- Initiatives with nothing linked belong to the new/quiet boxes;
+            -- excluding them here keeps every row on the page unique.
+            HAVING activity_count > 0
+            ORDER BY last_touched DESC
+            LIMIT :limit
+            """,
+            {"me": person_id, "cutoff": cutoff, "limit": limit},
+        )
+        initiatives = _rows(cur)
+        if not initiatives:
+            return []
+
+        # Activity events per initiative, inside the window. person_on marks the
+        # activities the viewer is personally linked to: on an initiative they own
+        # they see the whole stream, but on one they're only involved in (via an
+        # activity) they should see only their own work, not the owner's — one
+        # incidental link shouldn't flood the feed with someone else's activity.
+        ids = [i["id"] for i in initiatives]
+        marks = ",".join("?" * len(ids))
+        # One row per activity, not per version: MAX(a.version) with a bare
+        # column list is SQLite's documented "row holding the maximum" form, so
+        # an activity written three times in the window reads as its latest
+        # touch rather than three near-identical lines.
+        cur.execute(
+            f"""
+            SELECT ail.initiative_id,
+                   a.id   AS activity_id,
+                   a.name AS activity_name,
+                   MAX(a.version) AS version,
+                   a.timestamp,
+                   a.created_by,
+                   p.name AS actor_name,
+                   EXISTS(SELECT 1 FROM activity_people_links apl
+                          WHERE apl.activity_id = a.id AND apl.person_id = ?
+                            AND apl.{_LIVE}) AS person_on
+            FROM activity_initiative_links ail
+            JOIN activities a ON a.id = ail.activity_id
+            LEFT JOIN people p
+              ON p.id = a.created_by AND p.version = (
+                   SELECT MAX(v.version) FROM people v WHERE v.id = p.id)
+            WHERE ail.initiative_id IN ({marks})
+              AND ail.status IS NOT 'deleted'
+              AND a.status IS NOT 'deleted'
+              AND a.timestamp >= ?
+            GROUP BY ail.initiative_id, a.id
+            ORDER BY a.timestamp DESC
+            """,
+            [person_id] + ids + [cutoff],
+        )
+        events = _rows(cur)
+
+        by_initiative = {}
+        for e in events:
+            e["verb"] = "added" if e["version"] == 1 else "edited"
+            by_initiative.setdefault(e["initiative_id"], []).append(e)
+
+        result = []
+        for i in initiatives:
+            owned = i["responsible_person"] == person_id or (
+                i["responsible_person"] is None and i["created_by"] == person_id
+            )
+            evs = by_initiative.get(i["id"], [])
+            if scope == "mine" and not owned:
+                # Only involved via an activity: show just my own activities, and
+                # drop the initiative entirely if none of them are mine in-window.
+                evs = [e for e in evs if e["person_on"]]
+                if not evs:
+                    continue
+                i["activity_count"] = len(evs)
+                i["involved_only"] = True
+            else:
+                i["involved_only"] = False
+            i["events"] = evs[:5]
+            result.append(i)
+        return result
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------
+# Section 2 — Near your work (Mine only)
+# ---------------------------------------------------------
+def near_your_work(person_id, window_days, limit=10):
+    """
+    Activities somebody else recorded against an initiative that is yours —
+    whether you own it or are involved in it via one of your own activities —
+    where you are not yet linked to the activity. The prompt is "you may have
+    been part of this", hence the exclusion of activities you're already on.
+
+    Each row carries `owned` = you're the responsible person for its initiative.
+    The default view shows only owned rows; the involved-in rows (owned == 0) are
+    the broadened set, revealed on demand, so one incidental activity link doesn't
+    flood the section with a busy initiative's whole history.
+
+    Scoped to Mine-initiatives (reusing _MINE_INITIATIVE_IDS). `limit` applies to
+    each group (owned / involved) separately.
+    """
+    if not person_id:
+        return []
+
+    cutoff = _cutoff_iso(window_days)
+    conn = db_connect()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            f"""
+            SELECT a.id        AS activity_id,
+                   a.name      AS activity_name,
+                   a.timestamp,
+                   i.id        AS initiative_id,
+                   i.name      AS initiative_name,
+                   p.name      AS actor_name,
+                   a.created_by,
+                   (i.responsible_person = :me) AS owned
+            FROM activity_initiative_links ail
+            JOIN activities a ON a.id = ail.activity_id
+            JOIN initiatives i ON i.id = ail.initiative_id
+            LEFT JOIN people p
+              ON p.id = a.created_by AND {_latest('people', 'p')}
+            WHERE ail.{_LIVE} AND a.{_LIVE}
+              AND {_latest('activities', 'a')}
+              AND {_latest('initiatives', 'i')} AND i.{_LIVE}
+              AND i.id IN ({_MINE_INITIATIVE_IDS})
+              AND a.timestamp >= :cutoff
+              AND (a.created_by IS NULL OR a.created_by != :me)
+              AND a.id NOT IN ({_MY_ACTIVITY_IDS})
+            GROUP BY a.id, i.id
+            ORDER BY a.timestamp DESC
+            """,
+            {"me": person_id, "cutoff": cutoff},
+        )
+        rows = _rows(cur)
+        owned = [r for r in rows if r["owned"]][:limit]
+        involved = [r for r in rows if not r["owned"]][:limit]
+        return owned + involved
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------
+# Sections 3 & 4 — initiatives with no activity linked
+# ---------------------------------------------------------
+def _empty_initiatives(person_id, window_days, scope, created_inside_window, limit):
+    """
+    Initiatives with nothing linked. Split on the window so the two boxes never
+    show the same row: `new` was created inside it, `quiet` before it.
+    """
+    if scope == "mine" and not person_id:
+        return []
+
+    cutoff = _cutoff_iso(window_days)
+    comparison = ">=" if created_inside_window else "<"
+    conn = db_connect()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            f"""
+            SELECT i.id,
+                   i.name,
+                   i.responsible_person,
+                   i.created_by,
+                   p.name AS responsible_name,
+                   c.name AS creator_name,
+                   (SELECT MIN(v.timestamp) FROM initiatives v WHERE v.id = i.id)
+                     AS created_at,
+                   i.timestamp AS last_touched
+            FROM initiatives i
+            LEFT JOIN people p
+              ON p.id = i.responsible_person AND {_latest('people', 'p')}
+            LEFT JOIN people c
+              ON c.id = i.created_by AND {_latest('people', 'c')}
+            WHERE {_latest('initiatives', 'i')} AND i.{_LIVE}
+              {_initiative_scope_clause(scope)}
+              AND i.id NOT IN (
+                SELECT l.initiative_id FROM activity_initiative_links l
+                WHERE l.{_LIVE}
+              )
+              AND (SELECT MIN(v.timestamp) FROM initiatives v WHERE v.id = i.id)
+                  {comparison} :cutoff
+            ORDER BY created_at DESC
+            LIMIT :limit
+            """,
+            {"me": person_id, "cutoff": cutoff, "limit": limit},
+        )
+        return _rows(cur)
+    finally:
+        conn.close()
+
+
+def new_without_activity(person_id, window_days, scope="mine", limit=10):
+    """Created inside the window, nothing linked yet."""
+    return _empty_initiatives(person_id, window_days, scope, True, limit)
+
+
+def quiet_initiatives(person_id, window_days, limit=10):
+    """
+    Created before the window and still nothing linked. Mine only, always:
+    scoped to yourself this is a personal to-do; scoped to everyone it would
+    be a report on other people's neglected projects.
+    """
+    return _empty_initiatives(person_id, window_days, "mine", False, limit)
+
+
+# ---------------------------------------------------------
+# Section 5 — activities not linked to any initiative (Mine only)
+# ---------------------------------------------------------
+def unlinked_activities(person_id, limit=10):
+    """Activities you're on that hang off no initiative, so no report reaches them."""
+    if not person_id:
+        return []
+
+    conn = db_connect()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            f"""
+            SELECT a.id, a.name, a.timestamp
+            FROM activities a
+            WHERE {_latest('activities', 'a')} AND a.{_LIVE}
+              AND a.id IN ({_MY_ACTIVITY_IDS})
+              AND a.id NOT IN (
+                SELECT l.activity_id FROM activity_initiative_links l
+                WHERE l.{_LIVE}
+              )
+            ORDER BY a.timestamp DESC
+            LIMIT :limit
+            """,
+            {"me": person_id, "limit": limit},
+        )
+        return _rows(cur)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------
+# Tag groups
+# ---------------------------------------------------------
+def tag_group_definitions():
+    """
+    {group_id: key_values} for the newest version of each tag group, used to
+    turn a stored tag value into the label a person chose from.
+    """
+    conn = db_connect()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            f"""
+            SELECT t.id, t.key_values FROM tag_groups t
+            WHERE {_latest('tag_groups', 't')} AND t.{_LIVE}
+            """
+        )
+        defs = {}
+        for gid, key_values in cur.fetchall():
+            try:
+                defs[str(gid)] = json.loads(key_values) if key_values else {}
+            except (json.JSONDecodeError, TypeError):
+                defs[str(gid)] = {}
+        return defs
+    finally:
+        conn.close()
+
+
+def format_tags(raw, defs):
+    """
+    Turn a stored tag_groups value into [(label, text)].
+
+    Two shapes exist in the data: the structured
+    {"<group_id>": {"<element>": ["<option>"]}}, and bare strings left by the
+    original import. Both have to render, and neither should ever surface as
+    raw JSON on the card.
+    """
+    if raw in (None, ""):
+        return []
+
+    value = raw
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return [(None, str(raw))]
+
+    if not isinstance(value, dict):
+        return [(None, str(value))]
+
+    out = []
+    for group_id, elements in value.items():
+        if not isinstance(elements, dict):
+            out.append((None, str(elements)))
+            continue
+        key_values = defs.get(str(group_id), {})
+        for element_key, element_val in elements.items():
+            cfg = key_values.get(element_key, {})
+            label = cfg.get("label") or element_key.replace("_", " ").title()
+            list_name = cfg.get("list_name")
+            options = cfg.get(list_name, {}) if list_name else {}
+            vals = element_val if isinstance(element_val, list) else [element_val]
+            text = ", ".join(
+                str(options.get(v, str(v).replace("_", " ").title()))
+                for v in vals
+                if v not in (None, "")
+            )
+            if text:
+                out.append((label, text))
+    return out
+
+
+# ---------------------------------------------------------
+# Detail cards
+# ---------------------------------------------------------
+def _one(cur):
+    row = cur.fetchone()
+    if not row:
+        return None
+    return dict(zip([c[0] for c in cur.description], row))
+
+
+def _person_name(cur, person_id):
+    if not person_id:
+        return None
+    cur.execute(
+        f"SELECT name FROM people p WHERE p.id = ? AND {_latest('people', 'p')}",
+        (person_id,),
+    )
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def initiative_name(initiative_id):
+    """The current name of one initiative, for labelling. None if it's gone."""
+    conn = db_connect()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            f"SELECT name FROM initiatives i "
+            f"WHERE i.id = ? AND {_latest('initiatives', 'i')} AND i.{_LIVE}",
+            (initiative_id,),
+        )
+        row = cur.fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def person_name(person_id):
+    """The current name of one person, for labelling. None if unknown."""
+    if not person_id:
+        return None
+    conn = db_connect()
+    cur = conn.cursor()
+    try:
+        return _person_name(cur, person_id)
+    finally:
+        conn.close()
+
+
+def initiative_detail(initiative_id):
+    """Everything the card shows for one initiative, including what it links to."""
+    conn = db_connect()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            f"""
+            SELECT i.id, i.name, i.description, i.status, i.tag_groups,
+                   i.responsible_person, i.created_by, i.version,
+                   i.timestamp AS last_updated,
+                   (SELECT MIN(v.timestamp) FROM initiatives v WHERE v.id = i.id)
+                     AS created_at
+            FROM initiatives i
+            WHERE i.id = :id AND {_latest('initiatives', 'i')}
+            """,
+            {"id": initiative_id},
+        )
+        detail = _one(cur)
+        if not detail:
+            return None
+        detail["responsible_name"] = _person_name(cur, detail["responsible_person"])
+        detail["creator_name"] = _person_name(cur, detail["created_by"])
+
+        # Activities linked to it
+        cur.execute(
+            f"""
+            SELECT a.id, a.name, a.start_date, a.end_date, a.timestamp
+            FROM activity_initiative_links l
+            JOIN activities a ON a.id = l.activity_id
+            WHERE l.initiative_id = :id AND l.{_LIVE}
+              AND {_latest('activities', 'a')} AND a.{_LIVE}
+            ORDER BY a.timestamp DESC
+            """,
+            {"id": initiative_id},
+        )
+        detail["activities"] = _rows(cur)
+
+        # Parents and children, which the initiative tree already encodes
+        cur.execute(
+            f"""
+            SELECT i.id, i.name, 'parent' AS relation
+            FROM initiative_initiative_links l
+            JOIN initiatives i ON i.id = l.parent_id
+            WHERE l.child_id = :id AND l.{_LIVE}
+              AND {_latest('initiatives', 'i')} AND i.{_LIVE}
+            UNION
+            SELECT i.id, i.name, 'child' AS relation
+            FROM initiative_initiative_links l
+            JOIN initiatives i ON i.id = l.child_id
+            WHERE l.parent_id = :id AND l.{_LIVE}
+              AND {_latest('initiatives', 'i')} AND i.{_LIVE}
+            ORDER BY relation, i.name
+            """,
+            {"id": initiative_id},
+        )
+        detail["related"] = _rows(cur)
+
+        # People reachable through its activities
+        cur.execute(
+            f"""
+            SELECT DISTINCT p.id, p.name
+            FROM activity_initiative_links l
+            JOIN activity_people_links pl ON pl.activity_id = l.activity_id
+            JOIN people p ON p.id = pl.person_id
+            WHERE l.initiative_id = :id AND l.{_LIVE} AND pl.{_LIVE}
+              AND {_latest('people', 'p')}
+            ORDER BY p.name
+            """,
+            {"id": initiative_id},
+        )
+        detail["people"] = _rows(cur)
+        return detail
+    finally:
+        conn.close()
+
+
+def activity_detail(activity_id):
+    """Everything the card shows for one activity."""
+    conn = db_connect()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            f"""
+            SELECT a.id, a.name, a.description, a.status, a.tag_groups,
+                   a.location, a.start_date, a.end_date, a.created_by, a.version,
+                   a.timestamp AS last_updated,
+                   (SELECT MIN(v.timestamp) FROM activities v WHERE v.id = a.id)
+                     AS created_at
+            FROM activities a
+            WHERE a.id = :id AND {_latest('activities', 'a')}
+            """,
+            {"id": activity_id},
+        )
+        detail = _one(cur)
+        if not detail:
+            return None
+        detail["creator_name"] = _person_name(cur, detail["created_by"])
+
+        cur.execute(
+            f"""
+            SELECT i.id, i.name
+            FROM activity_initiative_links l
+            JOIN initiatives i ON i.id = l.initiative_id
+            WHERE l.activity_id = :id AND l.{_LIVE}
+              AND {_latest('initiatives', 'i')} AND i.{_LIVE}
+            ORDER BY i.name
+            """,
+            {"id": activity_id},
+        )
+        detail["initiatives"] = _rows(cur)
+
+        cur.execute(
+            f"""
+            SELECT p.id, p.name, l.type
+            FROM activity_people_links l
+            JOIN people p ON p.id = l.person_id
+            WHERE l.activity_id = :id AND l.{_LIVE}
+              AND {_latest('people', 'p')}
+            ORDER BY p.name
+            """,
+            {"id": activity_id},
+        )
+        detail["people"] = _rows(cur)
+        return detail
+    finally:
+        conn.close()
+
+
+def my_totals(person_id):
+    """Counts for the header line. Never per-person totals for anyone else."""
+    if not person_id:
+        return {"initiatives": 0, "activities": 0}
+
+    conn = db_connect()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            f"SELECT COUNT(*) FROM ({_MINE_INITIATIVE_IDS})", {"me": person_id}
+        )
+        initiatives = cur.fetchone()[0]
+        cur.execute(
+            f"""
+            SELECT COUNT(DISTINCT a.id) FROM activities a
+            WHERE {_latest('activities', 'a')} AND a.{_LIVE}
+              AND a.id IN ({_MY_ACTIVITY_IDS})
+            """,
+            {"me": person_id},
+        )
+        activities = cur.fetchone()[0]
+        return {"initiatives": initiatives, "activities": activities}
+    finally:
+        conn.close()

--- a/collaboratorium/form_gen.py
+++ b/collaboratorium/form_gen.py
@@ -182,7 +182,7 @@ def register_click_callbacks(app, config):
         A prefill only applies to the table it was requested for, so a stale
         request can never leak into a different form. Returns (values, title).
         """
-        if not prefill or prefill.get("table") != table_name:
+        if not isinstance(prefill, dict) or prefill.get("table") != table_name:
             return None, None
         return prefill.get("values") or None, prefill.get("title")
 

--- a/collaboratorium/form_gen.py
+++ b/collaboratorium/form_gen.py
@@ -26,9 +26,21 @@ def _get_max_id_from_cursor(cur, table_name):
 # ==============================================================
 
 
-def generate_form_layout(form_name, forms_config, object_id=None):
-    """Generate a Dash form layout from a form config"""
-    record_data = get_latest_entry(form_name, forms_config, object_id) if object_id else {}
+def generate_form_layout(form_name, forms_config, object_id=None, initial_values=None, title=None):
+    """
+    Generate a Dash form layout from a form config.
+
+    initial_values pre-populates an add form, keyed by element name and using the
+    same shapes an edit form would load (so a links element takes a list of ids).
+
+    title overrides the heading (e.g. "Add activity to <initiative>"). It's part
+    of the form DOM, so it's set atomically when the form renders — no separate
+    callback to race.
+    """
+    if object_id:
+        record_data = get_latest_entry(form_name, forms_config, object_id)
+    else:
+        record_data = dict(initial_values or {})
 
     elements = []
     for element_name, element_def in forms_config[form_name].get("elements", {}).items():
@@ -50,8 +62,12 @@ def generate_form_layout(form_name, forms_config, object_id=None):
         ),
     ])
 
+    heading = title or (
+        f"Edit {forms_config[form_name]['label']}" if object_id
+        else f"Add {forms_config[form_name]['label']}"
+    )
     return html.Div([
-        html.H3(f"Edit {forms_config[form_name]['label']}" if object_id else f"Add {forms_config[form_name]['label']}", className="mb-4 text-primary"),
+        html.H3(heading, id="form-heading", className="mb-4 text-primary"),
         *meta_hidden,
         *elements,
         html.Div(meta, style={"marginTop": "25px", "marginBottom": "20px", "opacity": "0.7"}),
@@ -83,9 +99,10 @@ def register_click_callbacks(app, config):
         Input('url', 'hash'),
         State("current-person-id", "data"),
         Input("form-refresh", "data"),
+        State("form-prefill", "data"),
     )
     @login_required
-    def load_form(table_name, tap_node, tap_edge, url_hash, person_id, refresh_signal):
+    def load_form(table_name, tap_node, tap_edge, url_hash, person_id, refresh_signal, prefill):
         """
         Display form based on trigger: Add selector, Graph tap, or URL hash link.
         """
@@ -108,7 +125,8 @@ def register_click_callbacks(app, config):
         # If the table selector is the trigger, show the add form (explicit user choice)
         if trigger and trigger.startswith("table-selector"):
             if table_name:
-                return show_add_form(table_name, person_id)
+                values, title = _prefill_for(table_name, prefill)
+                return show_add_form(table_name, person_id, values, title)
             return "Select a table"
 
         # If cyto's tapEdgeData triggered, prefer edge form
@@ -125,7 +143,8 @@ def register_click_callbacks(app, config):
         # No explicit trigger (initial or programmatic call).
         # Fall back to previous behavior but prefer node/edge when both present.
         if table_name and not (tap_node or tap_edge):
-            return show_add_form(table_name, person_id)
+            values, title = _prefill_for(table_name, prefill)
+            return show_add_form(table_name, person_id, values, title)
 
         # Helper to decide which of node/edge is the most recent when both are present
         def _is_node_newer(n, e):
@@ -158,11 +177,22 @@ def register_click_callbacks(app, config):
         return html.Div("Select a table or click a node/edge in the graph.")
 
 
-    def show_add_form(table_name, person_id):
+    def _prefill_for(table_name, prefill):
+        """
+        A prefill only applies to the table it was requested for, so a stale
+        request can never leak into a different form. Returns (values, title).
+        """
+        if not prefill or prefill.get("table") != table_name:
+            return None, None
+        return prefill.get("values") or None, prefill.get("title")
+
+    def show_add_form(table_name, person_id, initial_values=None, title=None):
         if not table_name:
             return "Select a table"
         form_name = config["default_forms"][table_name]
-        return login_required(generate_form_layout)(form_name, forms_config=forms_config)
+        return login_required(generate_form_layout)(
+            form_name, forms_config=forms_config, initial_values=initial_values, title=title
+        )
 
 
     def show_node_form(tap_node, person_id):

--- a/collaboratorium/main.py
+++ b/collaboratorium/main.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from auth import server, login_required, register_auth_callbacks
 from admin_routes import register_admin_routes
 
-from dash import Dash, html, dcc, Input, Output, State, ctx
+from dash import Dash, html, dcc, Input, Output, State, ctx, no_update
 import dash_bootstrap_components as dbc
 import dash_cytoscape as cyto
 
@@ -19,6 +19,7 @@ from views.data_pipeline import register_pipeline_callbacks
 from views.tab_graph import register_graph_callbacks
 from views.tab_spreadsheet import register_spreadsheet_callbacks
 from views.tab_report import register_report_callbacks
+from views.tab_dashboard import generate_dashboard_layout, register_dashboard_callbacks
 from tools.analysis_report import init_analytics_app
 
 # ---------------------------------------------------------
@@ -109,20 +110,70 @@ app.layout = html.Div([
     dcc.Store(id="current-person-id", data=None),
     dcc.Store(id="form-refresh", data=False),
     dcc.Store(id="current-view-state", data="view-degree"),
+    # The Dashboard is the landing page: it answers "what have I put in" before
+    # Explore asks you to describe a query.
+    dcc.Store(id="page-store", data="dashboard"),
+    # Lets a page request an add-form with fields already filled in, e.g. a new
+    # activity that arrives already linked to the initiative you started from.
+    dcc.Store(id="form-prefill", data=None),
 
     dbc.Container([
         dbc.Row([
-            dbc.Col(html.H2(config["title"], className="mb-4"), width=6),
+            dbc.Col(html.H2(config["title"], className="mb-4"), width=3),
             dbc.Col([
-                dbc.Button([html.I(className="bi bi-plus-circle me-2"), "Add Element"], id="btn-add-element", color="success", className="me-3 fw-bold"),
+                dbc.Button("Dashboard", id="nav-dashboard", n_clicks=0, className="nav-page-btn active me-1"),
+                dbc.Button("Explore", id="nav-explore", n_clicks=0, className="nav-page-btn"),
+            ], width=3, className="text-center"),
+            # Wide enough for three buttons and the user block to share one line.
+            dbc.Col([
+                # The two most common things to add lead as solid buttons; the
+                # catch-all "Add Element" (any of the other tables) recedes to a
+                # quiet link so three green buttons don't compete. The plus is
+                # text, not an icon: the Bootstrap Icons font isn't loaded here.
+                dbc.Button("+ Activity", id="btn-add-activity", color="success", className="me-2 fw-bold"),
+                dbc.Button("+ Initiative", id="btn-add-initiative", color="success", className="me-2 fw-bold"),
+                dbc.Button("Add other…", id="btn-add-element", color="link", size="sm", className="me-3 text-secondary"),
                 html.Div(id="login-area", style={"display": "inline-block"})
             ], width=6, className="text-end")
         ]),
 
-        main_content_row,
+        html.Div(generate_dashboard_layout(config), id="dashboard-container"),
+        html.Div(main_content_row, id="explore-container", style={"display": "none"}),
         editor_container
     ], fluid=True, className="p-4")
 ], style={'minHeight': '100vh', 'backgroundColor': 'var(--idems-bg)'})
+
+
+@app.callback(
+    Output("dashboard-container", "style"),
+    Output("explore-container", "style"),
+    Output("nav-dashboard", "className"),
+    Output("nav-explore", "className"),
+    Output("page-store", "data", allow_duplicate=True),
+    Input("nav-dashboard", "n_clicks"),
+    Input("nav-explore", "n_clicks"),
+    Input("page-store", "data"),
+    prevent_initial_call='initial_duplicate'
+)
+def switch_page(_dash_clicks, _explore_clicks, page):
+    """Toggles CSS display so neither page loses its state on navigation."""
+    trigger = ctx.triggered_id
+    if trigger == "nav-dashboard":
+        page = "dashboard"
+    elif trigger == "nav-explore":
+        page = "explore"
+    page = page or "dashboard"
+
+    # The store is both an input and an output here, so that other pages (the
+    # dashboard's hand-off) can drive navigation. Echoing it back when it was
+    # the trigger would just re-enter this callback.
+    store = no_update if trigger == "page-store" else page
+
+    on, off = "nav-page-btn active me-1", "nav-page-btn me-1"
+    show, hide = {"display": "block"}, {"display": "none"}
+    if page == "explore":
+        return hide, show, off, "nav-page-btn active", store
+    return show, hide, on, "nav-page-btn", store
 
 
 # Add state persistence listener to automatically trigger modal visibilities on input events
@@ -153,6 +204,7 @@ def handle_editor_visibility(table_val, node_data, edge_data, url_hash, is_open_
 register_auth_callbacks(app)
 register_form_callbacks(app, config)
 register_layout_callbacks(app, config)
+register_dashboard_callbacks(app, config)
 register_pipeline_callbacks(app, config)
 register_graph_callbacks(app, config)
 register_spreadsheet_callbacks(app, config)

--- a/collaboratorium/views/tab_dashboard.py
+++ b/collaboratorium/views/tab_dashboard.py
@@ -7,7 +7,6 @@ registry or the YAML pipeline — it is a fixed read-only projection, so the
 layout is hand-built and the queries live in dashboard_data.py. It never
 writes: every action hands off to the existing generic editor or to Explore.
 """
-import itertools
 from datetime import datetime
 
 from dash import html, dcc, Input, Output, State, ctx, ALL, no_update
@@ -39,10 +38,14 @@ DEFAULT_WINDOW = 90
 
 # The same record legitimately appears more than once on the page: an activity
 # linked to three initiatives shows under each, and an initiative can be both in
-# the feed and in "Touching your work". Dash silently stops dispatching a
+# the feed and in "Near Your Work". Dash silently stops dispatching a
 # pattern-matching callback when two components share an id, so every generated
-# id carries a unique slot. The counter only has to be unique within a render.
-_slot = itertools.count()
+# id carries a "slot" that makes it unique. Slots are built from the render
+# context (section + parent + entity), so they stay stable across renders and
+# React can update in place instead of remounting.
+def _slot_id(base, *parts):
+    """A stable, render-context-unique value for a pattern-matching id's slot."""
+    return "-".join([base, *(str(p) for p in parts)])
 
 
 def _dash_cfg(config):
@@ -109,15 +112,23 @@ def _chip(kind):
     return html.Span(kind.title(), className=f"dash-chip dash-chip-{kind}")
 
 
-def _entity_link(kind, entity_id, name, className="dash-entity-link"):
-    """Opens the detail card. Used for feed rows and for links inside a card."""
+def _entity_link(kind, entity_id, name, className="dash-entity-link", slot=None):
+    """Opens the detail card. Used for feed rows and for links inside a card.
+
+    ``slot`` disambiguates otherwise-identical ids. The same entity can appear in
+    several rows at once (an activity linked to multiple initiatives), and Dash
+    silently stops dispatching a pattern-matching callback when two components
+    share an id. Pass a value that is stable across renders (so React reuses the
+    DOM rather than remounting) yet unique within one render; it defaults to
+    kind+id, which is enough only when the entity appears once.
+    """
     return html.A(
         name or f"{kind[:-1].title()} {entity_id}",
         id={
             "type": "dash-open",
             "kind": kind,
             "index": int(entity_id),
-            "slot": next(_slot),
+            "slot": slot if slot is not None else f"{kind}-{entity_id}",
         },
         className=className,
         n_clicks=0,
@@ -125,12 +136,15 @@ def _entity_link(kind, entity_id, name, className="dash-entity-link"):
     )
 
 
-def _initiative_link(initiative_id, name):
-    return _entity_link("initiatives", initiative_id, name)
+def _initiative_link(initiative_id, name, slot=None):
+    return _entity_link("initiatives", initiative_id, name, slot=slot)
 
 
-def _activity_link(activity_id, name):
-    return _entity_link("activities", activity_id, name, className="dash-entity-link dash-ev-name")
+def _activity_link(activity_id, name, slot=None):
+    return _entity_link(
+        "activities", activity_id, name,
+        className="dash-entity-link dash-ev-name", slot=slot,
+    )
 
 
 def _panel(title, count=None, children=None, subtitle=None, header_extra=None):
@@ -165,7 +179,7 @@ def _render_recent(initiatives, scope, person_id=None, read_only=False):
                 actions.append(
                     dbc.Button(
                         "Add an activity",
-                        id={"type": "dash-empty-add-activity", "slot": next(_slot)},
+                        id={"type": "dash-empty-add-activity", "slot": "empty"},
                         className="dash-mini dash-mini-go",
                         n_clicks=0,
                     )
@@ -173,7 +187,7 @@ def _render_recent(initiatives, scope, person_id=None, read_only=False):
             actions.append(
                 dbc.Button(
                     "See the whole organisation",
-                    id={"type": "dash-empty-everyone", "slot": next(_slot)},
+                    id={"type": "dash-empty-everyone", "slot": "empty"},
                     className="dash-mini",
                     n_clicks=0,
                 )
@@ -202,7 +216,10 @@ def _render_recent(initiatives, scope, person_id=None, read_only=False):
                 html.Div(
                     [
                         _chip("activity"),
-                        _activity_link(e["activity_id"], e["activity_name"]),
+                        _activity_link(
+                            e["activity_id"], e["activity_name"],
+                            slot=_slot_id("recent", i["id"], e["activity_id"]),
+                        ),
                         html.Span(className="dash-spacer"),
                         _avatar(e.get("actor_name")),
                         html.Span(e["verb"], className="dash-verb"),
@@ -229,7 +246,9 @@ def _render_recent(initiatives, scope, person_id=None, read_only=False):
                     html.Div(
                         [
                             _chip("initiative"),
-                            _initiative_link(i["id"], i["name"]),
+                            _initiative_link(
+                                i["id"], i["name"], slot=_slot_id("recent-init", i["id"]),
+                            ),
                             html.Span(className="dash-spacer"),
                             html.Span(_fmt_date(i["last_touched"]), className="dash-ts"),
                         ],
@@ -247,7 +266,10 @@ def _render_recent(initiatives, scope, person_id=None, read_only=False):
 
 
 def _near_row(t, read_only):
-    why = [html.Span(["on ", _initiative_link(t["initiative_id"], t["initiative_name"])])]
+    why = [html.Span(["on ", _initiative_link(
+        t["initiative_id"], t["initiative_name"],
+        slot=_slot_id("near", t["activity_id"], "init", t["initiative_id"]),
+    )])]
     if not read_only:
         why.append(html.Span(className="dash-spacer"))
         why.append(
@@ -255,7 +277,11 @@ def _near_row(t, read_only):
                 # Ellipsis: this opens the activity's form to add yourself,
                 # rather than adding you in one click.
                 "Add yourself…",
-                id={"type": "dash-add-self", "index": int(t["activity_id"]), "slot": next(_slot)},
+                id={
+                    "type": "dash-add-self",
+                    "index": int(t["activity_id"]),
+                    "slot": _slot_id("near", t["activity_id"]),
+                },
                 className="dash-mini",
                 n_clicks=0,
             )
@@ -265,7 +291,10 @@ def _near_row(t, read_only):
             html.Div(
                 [
                     _chip("activity"),
-                    _activity_link(t["activity_id"], t["activity_name"]),
+                    _activity_link(
+                        t["activity_id"], t["activity_name"],
+                        slot=_slot_id("near", t["activity_id"], "act"),
+                    ),
                     html.Span(className="dash-spacer"),
                     _avatar(t.get("actor_name")),
                     html.Span("linked", className="dash-verb"),
@@ -363,7 +392,11 @@ def _render_new(items, scope, read_only=False):
             meta.append(
                 dbc.Button(
                     "Add activity",
-                    id={"type": "dash-add-activity", "index": int(r["id"]), "slot": next(_slot)},
+                    id={
+                        "type": "dash-add-activity",
+                        "index": int(r["id"]),
+                        "slot": _slot_id("new", r["id"]),
+                    },
                     className="dash-mini dash-mini-go",
                     n_clicks=0,
                 )
@@ -371,7 +404,10 @@ def _render_new(items, scope, read_only=False):
         rows.append(
             html.Div(
                 [
-                    html.P(_initiative_link(r["id"], r["name"]), className="dash-item-n"),
+                    html.P(
+                        _initiative_link(r["id"], r["name"], slot=_slot_id("new-init", r["id"])),
+                        className="dash-item-n",
+                    ),
                     html.Div(meta, className="dash-item-m"),
                 ],
                 className="dash-item dash-invite",
@@ -409,7 +445,11 @@ def _render_quiet(items, hidden, read_only=False):
             meta.append(
                 dbc.Button(
                     "Add activity",
-                    id={"type": "dash-add-activity", "index": int(r["id"]), "slot": next(_slot)},
+                    id={
+                        "type": "dash-add-activity",
+                        "index": int(r["id"]),
+                        "slot": _slot_id("quiet", r["id"]),
+                    },
                     className="dash-mini",
                     n_clicks=0,
                 )
@@ -417,7 +457,10 @@ def _render_quiet(items, hidden, read_only=False):
         rows.append(
             html.Div(
                 [
-                    html.P(_initiative_link(r["id"], r["name"]), className="dash-item-n"),
+                    html.P(
+                        _initiative_link(r["id"], r["name"], slot=_slot_id("quiet-init", r["id"])),
+                        className="dash-item-n",
+                    ),
                     html.Div(meta, className="dash-item-m"),
                 ],
                 className="dash-item",
@@ -452,7 +495,11 @@ def _render_unlinked(items, read_only=False):
             meta.append(
                 dbc.Button(
                     "Link an initiative",
-                    id={"type": "dash-link-initiative", "index": int(a["id"]), "slot": next(_slot)},
+                    id={
+                        "type": "dash-link-initiative",
+                        "index": int(a["id"]),
+                        "slot": _slot_id("unlinked", a["id"]),
+                    },
                     className="dash-mini",
                     n_clicks=0,
                 )
@@ -460,7 +507,10 @@ def _render_unlinked(items, read_only=False):
         rows.append(
             html.Div(
                 [
-                    html.P(_activity_link(a["id"], a["name"]), className="dash-item-n"),
+                    html.P(
+                        _activity_link(a["id"], a["name"], slot=_slot_id("unlinked-act", a["id"])),
+                        className="dash-item-n",
+                    ),
                     html.Div(meta, className="dash-item-m"),
                 ],
                 className="dash-item",
@@ -523,7 +573,10 @@ def _linked_list(title, items, kind):
             html.P(title, className="dash-card-sec"),
             html.Div(
                 [
-                    html.Div(_entity_link(kind, r["id"], r["name"]), className="dash-linked-row")
+                    html.Div(
+                        _entity_link(kind, r["id"], r["name"], slot=_slot_id("card", kind, r["id"])),
+                        className="dash-linked-row",
+                    )
                     for r in items
                 ],
                 className="dash-linked",
@@ -562,7 +615,11 @@ def _card_footer(kind, entity_id, read_only=False):
             buttons.append(
                 dbc.Button(
                     "Add activity",
-                    id={"type": "dash-add-activity", "index": int(entity_id), "slot": next(_slot)},
+                    id={
+                        "type": "dash-add-activity",
+                        "index": int(entity_id),
+                        "slot": _slot_id("card", entity_id),
+                    },
                     className="dash-mini dash-mini-go me-2",
                     n_clicks=0,
                 )

--- a/collaboratorium/views/tab_dashboard.py
+++ b/collaboratorium/views/tab_dashboard.py
@@ -1,0 +1,1077 @@
+"""
+tab_dashboard.py
+The Dashboard page: what you've put in, so you notice what you haven't.
+
+Deliberately rigid. Unlike the Explore page this is not driven by the filter
+registry or the YAML pipeline — it is a fixed read-only projection, so the
+layout is hand-built and the queries live in dashboard_data.py. It never
+writes: every action hands off to the existing generic editor or to Explore.
+"""
+import itertools
+from datetime import datetime
+
+from dash import html, dcc, Input, Output, State, ctx, ALL, no_update
+import dash_bootstrap_components as dbc
+
+from flask import session
+
+import admin_routes
+from auth import login_required
+from db import get_dropdown_options
+from dashboard_data import (
+    activity_detail,
+    format_tags,
+    initiative_detail,
+    initiative_name,
+    my_totals,
+    new_without_activity,
+    person_name,
+    quiet_initiatives,
+    recently_updated,
+    tag_group_definitions,
+    near_your_work,
+    unlinked_activities,
+)
+from report_generator import format_subform_data
+
+WINDOW_OPTIONS = [30, 90]
+DEFAULT_WINDOW = 90
+
+# The same record legitimately appears more than once on the page: an activity
+# linked to three initiatives shows under each, and an initiative can be both in
+# the feed and in "Touching your work". Dash silently stops dispatching a
+# pattern-matching callback when two components share an id, so every generated
+# id carries a unique slot. The counter only has to be unique within a render.
+_slot = itertools.count()
+
+
+def _dash_cfg(config):
+    return config.get("dashboard", {}) or {}
+
+
+def _is_admin():
+    """True if the current session belongs to an admin (reuses ADMIN_EMAILS).
+
+    Reads the list off the module at call time so it reflects env/config and can
+    be monkeypatched in tests.
+    """
+    user = session.get("user")
+    return bool(user and user.get("email") in admin_routes.ADMIN_EMAILS)
+
+
+def _view_as_banner(view_as_id):
+    name = person_name(view_as_id) or f"person {view_as_id}"
+    return html.Div(
+        [
+            html.Span(f"Viewing as {name}", className="dash-viewas-name"),
+            html.Span("read-only", className="dash-viewas-tag"),
+        ],
+        className="dash-viewas-banner",
+    )
+
+
+# ---------------------------------------------------------
+# Small presentational helpers
+# ---------------------------------------------------------
+def _fmt_date(ts):
+    """'2026-06-02T13:46:25' -> '2 Jun'. Falls back to raw text."""
+    if not ts:
+        return ""
+    try:
+        dt = datetime.fromisoformat(str(ts).replace(" ", "T").split(".")[0])
+    except (ValueError, TypeError):
+        return str(ts)[:10]
+    # Built by hand rather than strftime("%-d"), which is not portable to Windows.
+    if dt.year != datetime.now().year:
+        return f"{dt.day} {dt.strftime('%b')} {dt.year}"
+    return f"{dt.day} {dt.strftime('%b')}"
+
+
+def _initials(name):
+    if not name:
+        return "?"
+    parts = [p for p in str(name).replace("_", " ").split() if p]
+    if not parts:
+        return "?"
+    if len(parts) == 1:
+        return parts[0][:2].upper()
+    return (parts[0][0] + parts[-1][0]).upper()
+
+
+def _avatar(name):
+    """A face is provenance, never a score. Unattributed rows stay graceful."""
+    if not name:
+        return html.Span("—", className="dash-avatar dash-avatar-none", title="Unattributed")
+    return html.Span(_initials(name), className="dash-avatar", title=str(name))
+
+
+def _chip(kind):
+    return html.Span(kind.title(), className=f"dash-chip dash-chip-{kind}")
+
+
+def _entity_link(kind, entity_id, name, className="dash-entity-link"):
+    """Opens the detail card. Used for feed rows and for links inside a card."""
+    return html.A(
+        name or f"{kind[:-1].title()} {entity_id}",
+        id={
+            "type": "dash-open",
+            "kind": kind,
+            "index": int(entity_id),
+            "slot": next(_slot),
+        },
+        className=className,
+        n_clicks=0,
+        href="#",
+    )
+
+
+def _initiative_link(initiative_id, name):
+    return _entity_link("initiatives", initiative_id, name)
+
+
+def _activity_link(activity_id, name):
+    return _entity_link("activities", activity_id, name, className="dash-entity-link dash-ev-name")
+
+
+def _panel(title, count=None, children=None, subtitle=None, header_extra=None):
+    header = [html.Span(title)]
+    if header_extra is not None:
+        header.append(html.Span(className="dash-spacer"))
+        header.append(header_extra)
+    if count is not None:
+        header.append(html.Span(str(count), className="dash-count"))
+    body = []
+    if subtitle:
+        body.append(html.P(subtitle, className="dash-panel-sub"))
+    body.extend(children or [])
+    return html.Div(
+        [html.Div(header, className="dash-panel-h"), html.Div(body)],
+        className="dash-panel",
+    )
+
+
+def _empty(message):
+    return html.P(message, className="dash-empty")
+
+
+# ---------------------------------------------------------
+# Section renderers
+# ---------------------------------------------------------
+def _render_recent(initiatives, scope, person_id=None, read_only=False):
+    if not initiatives:
+        if scope == "mine":
+            actions = []
+            if not read_only:
+                actions.append(
+                    dbc.Button(
+                        "Add an activity",
+                        id={"type": "dash-empty-add-activity", "slot": next(_slot)},
+                        className="dash-mini dash-mini-go",
+                        n_clicks=0,
+                    )
+                )
+            actions.append(
+                dbc.Button(
+                    "See the whole organisation",
+                    id={"type": "dash-empty-everyone", "slot": next(_slot)},
+                    className="dash-mini",
+                    n_clicks=0,
+                )
+            )
+            body = [
+                _empty(
+                    "Nothing of yours was recorded in this window. Record what "
+                    "you've been working on, or look at the whole organisation."
+                ),
+                html.Div(actions, className="dash-empty-actions"),
+            ]
+        else:
+            body = [
+                _empty(
+                    "Nothing was recorded across the organisation in this window. "
+                    "Try a longer one."
+                )
+            ]
+        return _panel("Recently updated", children=body)
+
+    rows = []
+    for i in initiatives:
+        events = []
+        for e in i["events"]:
+            events.append(
+                html.Div(
+                    [
+                        _chip("activity"),
+                        _activity_link(e["activity_id"], e["activity_name"]),
+                        html.Span(className="dash-spacer"),
+                        _avatar(e.get("actor_name")),
+                        html.Span(e["verb"], className="dash-verb"),
+                        html.Span(_fmt_date(e["timestamp"]), className="dash-ts"),
+                    ],
+                    className="dash-ev",
+                )
+            )
+
+        count = i["activity_count"]
+        activities = f"{count} {'activity' if count == 1 else 'activities'}"
+        # "You're responsible" only when you actually are — an initiative can be
+        # in Mine because you're on one of its activities, not because you own it.
+        if person_id is not None and i["responsible_person"] == person_id:
+            sub = f"You're responsible · {activities}"
+        elif i["responsible_name"]:
+            sub = f"{i['responsible_name']} responsible · {activities}"
+        else:
+            sub = f"No one responsible yet · {activities}"
+
+        rows.append(
+            html.Div(
+                [
+                    html.Div(
+                        [
+                            _chip("initiative"),
+                            _initiative_link(i["id"], i["name"]),
+                            html.Span(className="dash-spacer"),
+                            html.Span(_fmt_date(i["last_touched"]), className="dash-ts"),
+                        ],
+                        className="dash-repo-h",
+                    ),
+                    html.P(sub, className="dash-repo-sub"),
+                    html.Div(events, className="dash-ev-list") if events else None,
+                ],
+                className="dash-repo",
+            )
+        )
+
+    label = f"{len(initiatives)} initiatives" if len(initiatives) != 1 else "1 initiative"
+    return _panel("Recently updated", count=label, children=rows)
+
+
+def _near_row(t, read_only):
+    why = [html.Span(["on ", _initiative_link(t["initiative_id"], t["initiative_name"])])]
+    if not read_only:
+        why.append(html.Span(className="dash-spacer"))
+        why.append(
+            dbc.Button(
+                # Ellipsis: this opens the activity's form to add yourself,
+                # rather than adding you in one click.
+                "Add yourself…",
+                id={"type": "dash-add-self", "index": int(t["activity_id"]), "slot": next(_slot)},
+                className="dash-mini",
+                n_clicks=0,
+            )
+        )
+    return html.Div(
+        [
+            html.Div(
+                [
+                    _chip("activity"),
+                    _activity_link(t["activity_id"], t["activity_name"]),
+                    html.Span(className="dash-spacer"),
+                    _avatar(t.get("actor_name")),
+                    html.Span("linked", className="dash-verb"),
+                    html.Span(_fmt_date(t["timestamp"]), className="dash-ts"),
+                ],
+                className="dash-touch-h",
+            ),
+            html.Div(why, className="dash-touch-why"),
+        ],
+        className="dash-touch",
+    )
+
+
+def _render_near_your_work(owned, involved, expanded, read_only=False):
+    """
+    Owned rows (initiatives you're responsible for) show by default. The
+    involved-in rows — work near activities you've contributed to but don't own —
+    sit behind a per-person toggle so one incidental link can't flood the section
+    with a busy initiative's whole history.
+    """
+    if not owned and not involved:
+        return None
+
+    subtitle = (
+        "Someone else recorded something on an initiative you own or have "
+        "worked on, that you're not linked to. You may have been part of it."
+    )
+
+    # Nothing on your own initiatives, but there's activity near work you've
+    # contributed to: a compact prompt rather than an empty-looking section.
+    if not owned and not expanded:
+        return html.Div(
+            [
+                html.Span(f"{len(involved)} updates near work you've contributed to"),
+                html.Span(className="dash-spacer"),
+                dbc.Button(
+                    "Show",
+                    id={"type": "dash-near-toggle", "action": "expand"},
+                    className="dash-mini",
+                    n_clicks=0,
+                ),
+            ],
+            className="dash-hidden-chip",
+        )
+
+    rows = [_near_row(t, read_only) for t in owned]
+    if expanded:
+        rows.extend(_near_row(t, read_only) for t in involved)
+        if involved:
+            rows.append(
+                html.Div(
+                    dbc.Button(
+                        "Show less",
+                        id={"type": "dash-near-toggle", "action": "collapse"},
+                        className="dash-mini",
+                        n_clicks=0,
+                    ),
+                    className="dash-near-more",
+                )
+            )
+    elif involved:
+        rows.append(
+            html.Div(
+                dbc.Button(
+                    f"Show {len(involved)} more from initiatives you've contributed to",
+                    id={"type": "dash-near-toggle", "action": "expand"},
+                    className="dash-mini",
+                    n_clicks=0,
+                ),
+                className="dash-near-more",
+            )
+        )
+
+    shown = len(owned) + (len(involved) if expanded else 0)
+    return _panel("Near Your Work", count=shown, subtitle=subtitle, children=rows)
+
+
+def _render_new(items, scope, read_only=False):
+    if not items:
+        return None
+    rows = []
+    for r in items:
+        if scope == "mine":
+            meta = [html.Span(f"created {_fmt_date(r['created_at'])}", className="dash-ts")]
+        elif r["responsible_name"]:
+            meta = [
+                _avatar(r["responsible_name"]),
+                html.Span(r["responsible_name"]),
+                html.Span(_fmt_date(r["created_at"]), className="dash-ts"),
+            ]
+        else:
+            meta = [html.Span("no one responsible yet", className="dash-ts")]
+        if not read_only:
+            meta.append(html.Span(className="dash-spacer"))
+            meta.append(
+                dbc.Button(
+                    "Add activity",
+                    id={"type": "dash-add-activity", "index": int(r["id"]), "slot": next(_slot)},
+                    className="dash-mini dash-mini-go",
+                    n_clicks=0,
+                )
+            )
+        rows.append(
+            html.Div(
+                [
+                    html.P(_initiative_link(r["id"], r["name"]), className="dash-item-n"),
+                    html.Div(meta, className="dash-item-m"),
+                ],
+                className="dash-item dash-invite",
+            )
+        )
+    return _panel("New — no activity yet", count=len(items), children=rows)
+
+
+def _render_quiet(items, hidden, read_only=False):
+    """Mine only, and switchable — hiding it is never a one-way door."""
+    if hidden:
+        return html.Div(
+            [
+                html.Span("Nothing recorded in a while · hidden"),
+                html.Span(className="dash-spacer"),
+                dbc.Button(
+                    "Show",
+                    id={"type": "dash-quiet-toggle", "action": "show"},
+                    className="dash-mini",
+                    n_clicks=0,
+                ),
+            ],
+            className="dash-hidden-chip",
+        )
+    if not items:
+        return None
+
+    rows = []
+    for r in items:
+        meta = [
+            html.Span(f"nothing since {_fmt_date(r['created_at'])}", className="dash-ts"),
+        ]
+        if not read_only:
+            meta.append(html.Span(className="dash-spacer"))
+            meta.append(
+                dbc.Button(
+                    "Add activity",
+                    id={"type": "dash-add-activity", "index": int(r["id"]), "slot": next(_slot)},
+                    className="dash-mini",
+                    n_clicks=0,
+                )
+            )
+        rows.append(
+            html.Div(
+                [
+                    html.P(_initiative_link(r["id"], r["name"]), className="dash-item-n"),
+                    html.Div(meta, className="dash-item-m"),
+                ],
+                className="dash-item",
+            )
+        )
+    # The hide toggle is a personal preference, so it only makes sense on your own
+    # page — not while viewing someone else's read-only.
+    hide_btn = None if read_only else dbc.Button(
+        "✕",
+        id={"type": "dash-quiet-toggle", "action": "hide"},
+        className="dash-hide-x",
+        title="Hide this section",
+        n_clicks=0,
+    )
+    return _panel(
+        "Nothing recorded in a while",
+        count=len(items),
+        subtitle="Only ever your own. Never shown on Everyone.",
+        children=rows,
+        header_extra=hide_btn,
+    )
+
+
+def _render_unlinked(items, read_only=False):
+    if not items:
+        return None
+    rows = []
+    for a in items:
+        meta = [_chip("activity")]
+        if not read_only:
+            meta.append(html.Span(className="dash-spacer"))
+            meta.append(
+                dbc.Button(
+                    "Link an initiative",
+                    id={"type": "dash-link-initiative", "index": int(a["id"]), "slot": next(_slot)},
+                    className="dash-mini",
+                    n_clicks=0,
+                )
+            )
+        rows.append(
+            html.Div(
+                [
+                    html.P(_activity_link(a["id"], a["name"]), className="dash-item-n"),
+                    html.Div(meta, className="dash-item-m"),
+                ],
+                className="dash-item",
+            )
+        )
+    return _panel("Not linked to an initiative", count=len(items), children=rows)
+
+
+# ---------------------------------------------------------
+# Detail card
+# ---------------------------------------------------------
+def _facts(pairs):
+    """A definition list of the fields that have a value; blanks stay off the card."""
+    rows = []
+    for label, value in pairs:
+        if value in (None, "", "None"):
+            continue
+        rows.append(
+            html.Div(
+                [
+                    html.Span(label, className="dash-fact-k"),
+                    html.Span(value, className="dash-fact-v"),
+                ],
+                className="dash-fact",
+            )
+        )
+    return html.Div(rows, className="dash-facts") if rows else None
+
+
+def _prose(raw):
+    """Descriptions may hold subform JSON, so reuse the report's formatter."""
+    if raw in (None, ""):
+        return None
+    text = format_subform_data(raw)
+    if not str(text).strip():
+        return None
+    return dcc.Markdown(str(text), className="dash-prose", link_target="_blank")
+
+
+def _tag_chips(raw, defs):
+    tags = format_tags(raw, defs)
+    if not tags:
+        return None
+    chips = []
+    for label, text in tags:
+        chips.append(
+            html.Span(
+                [html.Span(f"{label}: ", className="dash-tag-k") if label else None, text],
+                className="dash-tag",
+            )
+        )
+    return html.Div(chips, className="dash-tags")
+
+
+def _linked_list(title, items, kind):
+    if not items:
+        return None
+    return html.Div(
+        [
+            html.P(title, className="dash-card-sec"),
+            html.Div(
+                [
+                    html.Div(_entity_link(kind, r["id"], r["name"]), className="dash-linked-row")
+                    for r in items
+                ],
+                className="dash-linked",
+            ),
+        ]
+    )
+
+
+def _people_list(title, items):
+    if not items:
+        return None
+    return html.Div(
+        [
+            html.P(title, className="dash-card-sec"),
+            html.Div(
+                [
+                    html.Span(
+                        [_avatar(r["name"]), html.Span(r["name"], className="dash-person-n")],
+                        className="dash-person",
+                    )
+                    for r in items
+                ],
+                className="dash-people",
+            ),
+        ]
+    )
+
+
+def _card_footer(kind, entity_id, read_only=False):
+    # Open in Explore is read-only navigation, so it stays even while impersonating;
+    # the write affordances (Add activity, Edit) drop out.
+    buttons = []
+    if not read_only:
+        if kind == "initiatives":
+            # Reading an initiative is exactly when you notice work you never entered.
+            buttons.append(
+                dbc.Button(
+                    "Add activity",
+                    id={"type": "dash-add-activity", "index": int(entity_id), "slot": next(_slot)},
+                    className="dash-mini dash-mini-go me-2",
+                    n_clicks=0,
+                )
+            )
+        buttons.append(
+            dbc.Button(
+                "Edit",
+                id={"type": "dash-card-edit", "kind": kind, "index": int(entity_id)},
+                className="dash-mini",
+                n_clicks=0,
+            )
+        )
+    return buttons + [
+        dbc.Button(
+            "Open in Explore →",
+            id={"type": "dash-card-explore", "kind": kind, "index": int(entity_id)},
+            className="dash-mini dash-mini-go ms-2",
+            n_clicks=0,
+        ),
+    ]
+
+
+def _render_initiative_card(detail, defs):
+    body = [
+        _facts(
+            [
+                ("Responsible", detail["responsible_name"] or "No one yet"),
+                ("Status", (detail["status"] or "").title()),
+                ("Activities", str(len(detail["activities"]))),
+                ("Created", _fmt_date(detail["created_at"])),
+                ("Last updated", _fmt_date(detail["last_updated"])),
+                ("Entered by", detail["creator_name"]),
+            ]
+        ),
+        _tag_chips(detail["tag_groups"], defs),
+        _prose(detail["description"]),
+        _linked_list("Activities", detail["activities"], "activities"),
+        _linked_list(
+            "Related initiatives",
+            [r for r in detail["related"]],
+            "initiatives",
+        ),
+        _people_list("People involved", detail["people"]),
+    ]
+    return [c for c in body if c is not None]
+
+
+def _render_activity_card(detail, defs):
+    dates = None
+    if detail["start_date"] and detail["end_date"]:
+        dates = f"{_fmt_date(detail['start_date'])} – {_fmt_date(detail['end_date'])}"
+    elif detail["start_date"] or detail["end_date"]:
+        dates = _fmt_date(detail["start_date"] or detail["end_date"])
+
+    body = [
+        _facts(
+            [
+                ("When", dates),
+                ("Location", detail["location"]),
+                ("Status", (detail["status"] or "").title()),
+                ("Created", _fmt_date(detail["created_at"])),
+                ("Last updated", _fmt_date(detail["last_updated"])),
+                ("Entered by", detail["creator_name"]),
+            ]
+        ),
+        _tag_chips(detail["tag_groups"], defs),
+        _prose(detail["description"]),
+        _linked_list("Part of", detail["initiatives"], "initiatives"),
+        _people_list("People involved", detail["people"]),
+    ]
+    return [c for c in body if c is not None]
+
+
+def _render_card(kind, entity_id, read_only=False):
+    defs = tag_group_definitions()
+    if kind == "initiatives":
+        detail = initiative_detail(entity_id)
+        if not detail:
+            return "Not found", [_empty("That initiative no longer exists.")], []
+        return (
+            html.Div([_chip("initiative"), html.Span(detail["name"], className="dash-card-t")],
+                     className="dash-card-h"),
+            _render_initiative_card(detail, defs),
+            _card_footer(kind, entity_id, read_only),
+        )
+
+    detail = activity_detail(entity_id)
+    if not detail:
+        return "Not found", [_empty("That activity no longer exists.")], []
+    return (
+        html.Div([_chip("activity"), html.Span(detail["name"], className="dash-card-t")],
+                 className="dash-card-h"),
+        _render_activity_card(detail, defs),
+        _card_footer(kind, entity_id, read_only),
+    )
+
+
+# ---------------------------------------------------------
+# Layout
+# ---------------------------------------------------------
+def generate_dashboard_layout(config):
+    cfg = _dash_cfg(config)
+    default_window = cfg.get("default_window_days", DEFAULT_WINDOW)
+    windows = cfg.get("window_options_days", WINDOW_OPTIONS)
+
+    return html.Div(
+        [
+            dcc.Store(id="dashboard-scope", data="mine"),
+            dcc.Store(id="dashboard-window", data=default_window),
+            # Per-person override for the quiet box. localStorage keeps it out of
+            # the schema entirely — there is no preferences table to add to.
+            dcc.Store(id="dashboard-hide-quiet", storage_type="local"),
+            # Whether "Near Your Work" is expanded to include initiatives you're
+            # involved in but don't own. Per-person, remembered in the browser.
+            dcc.Store(id="dashboard-near-expanded", storage_type="local"),
+            # Admin "view as": whose dashboard is being shown. None = yourself.
+            dcc.Store(id="view-as-person", data=None),
+            # Admin-only control. Hidden by default; a callback reveals and fills
+            # it only for an admin session (ADMIN_EMAILS), mirroring show_login_area.
+            html.Div(
+                dcc.Dropdown(
+                    id="view-as-pick",
+                    options=[],
+                    value=None,
+                    placeholder="View as… (admin)",
+                    className="dash-view-as-pick",
+                ),
+                id="view-as-container",
+                style={"display": "none"},
+            ),
+            html.Div(id="view-as-banner"),
+            html.Div(
+                [
+                    html.Div(
+                        [
+                            dbc.Button(
+                                "Mine",
+                                id="dash-scope-mine",
+                                n_clicks=0,
+                                className="dash-toggle-btn active",
+                            ),
+                            dbc.Button(
+                                "Everyone",
+                                id="dash-scope-everyone",
+                                n_clicks=0,
+                                className="dash-toggle-btn",
+                            ),
+                        ],
+                        className="dash-toggle",
+                    ),
+                    dcc.Dropdown(
+                        id="dash-window-pick",
+                        options=[{"label": f"Last {d} days", "value": d} for d in windows],
+                        value=default_window,
+                        clearable=False,
+                        className="dash-window-pick",
+                    ),
+                    html.Span(className="dash-spacer"),
+                    html.Span(id="dash-header-note", className="dash-ts"),
+                ],
+                className="dash-ctrl-row",
+            ),
+            dcc.Loading(html.Div(id="dashboard-body"), type="default"),
+            # Read-only inspector. Writing stays with the generic editor, which
+            # the Edit button opens.
+            dcc.Store(id="dashboard-detail", data=None),
+            dbc.Modal(
+                [
+                    dbc.ModalHeader(dbc.ModalTitle(html.Div(id="dash-card-header"))),
+                    dbc.ModalBody(html.Div(id="dash-card-body")),
+                    dbc.ModalFooter(
+                        [
+                            html.Div(id="dash-card-footer", className="dash-card-footer"),
+                            # Static, not part of the rendered footer: a plain-id
+                            # Input must exist in the layout tree or its callback
+                            # never fires.
+                            dbc.Button(
+                                "Close", id="dash-card-close", className="dash-mini", n_clicks=0
+                            ),
+                        ]
+                    ),
+                ],
+                id="dashboard-detail-modal",
+                is_open=False,
+                size="lg",
+                scrollable=True,
+            ),
+        ],
+        id="dashboard-page",
+    )
+
+
+# ---------------------------------------------------------
+# Callbacks
+# ---------------------------------------------------------
+def register_dashboard_callbacks(app, config):
+    cfg = _dash_cfg(config)
+    # Deployment-level default; a person can still switch it on their own page
+    # unless the deployment has turned the section off entirely.
+    quiet_enabled = cfg.get("show_quiet_box", True)
+
+    @app.callback(
+        Output("dashboard-scope", "data"),
+        Output("dash-scope-mine", "className"),
+        Output("dash-scope-everyone", "className"),
+        Input("dash-scope-mine", "n_clicks"),
+        Input("dash-scope-everyone", "n_clicks"),
+        Input({"type": "dash-empty-everyone", "slot": ALL}, "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def switch_scope(_mine, _everyone, empty_everyone):
+        trigger = ctx.triggered_id
+        to_everyone = trigger == "dash-scope-everyone" or (
+            isinstance(trigger, dict) and trigger.get("type") == "dash-empty-everyone"
+        )
+        # The empty-state button shares the pattern-matching quirk: ignore the
+        # render-time firing where no click has actually happened.
+        if isinstance(trigger, dict) and not ctx.triggered[0]["value"]:
+            return no_update, no_update, no_update
+        scope = "everyone" if to_everyone else "mine"
+        on, off = "dash-toggle-btn active", "dash-toggle-btn"
+        return scope, (off if scope == "everyone" else on), (on if scope == "everyone" else off)
+
+    @app.callback(
+        Output("dashboard-window", "data"),
+        Input("dash-window-pick", "value"),
+        prevent_initial_call=True,
+    )
+    def set_window(value):
+        return value or DEFAULT_WINDOW
+
+    @app.callback(
+        Output("dashboard-hide-quiet", "data"),
+        Input({"type": "dash-quiet-toggle", "action": ALL}, "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def toggle_quiet(clicks):
+        if not any(c for c in clicks if c):
+            return no_update
+        trigger = ctx.triggered_id
+        if not trigger:
+            return no_update
+        return trigger.get("action") == "hide"
+
+    @app.callback(
+        Output("dashboard-near-expanded", "data"),
+        Input({"type": "dash-near-toggle", "action": ALL}, "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def toggle_near_expanded(clicks):
+        if not any(c for c in clicks if c):
+            return no_update
+        trigger = ctx.triggered_id
+        if not trigger:
+            return no_update
+        return trigger.get("action") == "expand"
+
+    @app.callback(
+        Output("view-as-container", "style"),
+        Output("view-as-pick", "options"),
+        Input("current-person-id", "data"),
+    )
+    def reveal_view_as(_ready):
+        """Show the 'View as' control and its people list only for an admin."""
+        if not _is_admin():
+            return {"display": "none"}, []
+        return {"display": "inline-block"}, get_dropdown_options("people", "id", "name") or []
+
+    @app.callback(
+        Output("view-as-person", "data"),
+        Input("view-as-pick", "value"),
+        prevent_initial_call=True,
+    )
+    def set_view_as(value):
+        # Ignored server-side for non-admins (see render_dashboard), but don't even
+        # record it unless the session is an admin.
+        if not _is_admin():
+            return None
+        return value or None
+
+    @app.callback(
+        Output("btn-add-activity", "style"),
+        Output("btn-add-initiative", "style"),
+        Output("btn-add-element", "style"),
+        Input("view-as-person", "data"),
+    )
+    def hide_add_buttons_when_impersonating(view_as):
+        """The global add buttons write, so remove them while viewing as someone."""
+        hidden = {"display": "none"} if (view_as and _is_admin()) else None
+        return hidden, hidden, hidden
+
+    @app.callback(
+        Output("dashboard-body", "children"),
+        Output("dash-header-note", "children"),
+        Output("view-as-banner", "children"),
+        Input("dashboard-scope", "data"),
+        Input("dashboard-window", "data"),
+        Input("dashboard-hide-quiet", "data"),
+        Input("dashboard-near-expanded", "data"),
+        Input("current-person-id", "data"),
+        Input("view-as-person", "data"),
+        Input("form-refresh", "data"),
+        Input("page-store", "data"),
+    )
+    @login_required
+    def render_dashboard(scope, window, hide_quiet, near_expanded, person_id, view_as, _refresh, page):
+        if page != "dashboard":
+            return no_update, no_update, no_update
+
+        scope = scope or "mine"
+        window = window or DEFAULT_WINDOW
+
+        # "View as" is honoured only for an admin session; otherwise it's ignored,
+        # so a crafted store value can't impersonate. Impersonation is read-only.
+        read_only = bool(view_as) and _is_admin()
+        effective_id = view_as if read_only else person_id
+        banner = _view_as_banner(view_as) if read_only else None
+
+        if scope == "mine" and not effective_id:
+            return (
+                html.Div(
+                    _panel(
+                        "Recently updated",
+                        children=[
+                            _empty(
+                                "We couldn't match your login to a person record yet. "
+                                "Switch to Everyone to see what's happening across the organisation."
+                            )
+                        ],
+                    )
+                ),
+                "",
+                banner,
+            )
+
+        recent = recently_updated(effective_id, window, scope)
+        new_items = new_without_activity(effective_id, window, scope)
+
+        left = [_render_recent(recent, scope, effective_id, read_only)]
+        right = [_render_new(new_items, scope, read_only)]
+
+        if scope == "mine":
+            # Sections that need a "you" only exist on Mine. Showing the quiet
+            # box for everyone would make it a report on other people.
+            near = near_your_work(effective_id, window)
+            near_owned = [r for r in near if r["owned"]]
+            near_involved = [r for r in near if not r["owned"]]
+            left.append(
+                _render_near_your_work(near_owned, near_involved, bool(near_expanded), read_only)
+            )
+            if quiet_enabled:
+                right.append(
+                    _render_quiet(quiet_initiatives(effective_id, window), hide_quiet, read_only)
+                )
+            right.append(_render_unlinked(unlinked_activities(effective_id), read_only))
+            totals = my_totals(effective_id)
+            note = f"{totals['initiatives']} initiatives, {totals['activities']} activities"
+        else:
+            note = "everything across the organisation"
+
+        body = dbc.Row(
+            [
+                dbc.Col(html.Div([c for c in left if c], className="dash-stack"), lg=8, md=12),
+                dbc.Col(html.Div([c for c in right if c], className="dash-stack"), lg=4, md=12),
+            ],
+            className="g-3",
+        )
+        return body, note, banner
+
+    # -----------------------------------------------------
+    # Detail card
+    # -----------------------------------------------------
+    @app.callback(
+        Output("dashboard-detail", "data"),
+        Output("dashboard-detail-modal", "is_open"),
+        Input({"type": "dash-open", "kind": ALL, "index": ALL, "slot": ALL}, "n_clicks"),
+        Input("dash-card-close", "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def open_card(entity_clicks, _close):
+        trigger = ctx.triggered_id
+        if trigger == "dash-card-close":
+            return no_update, False
+        if not isinstance(trigger, dict) or not ctx.triggered[0]["value"]:
+            return no_update, no_update
+        return {"kind": trigger["kind"], "id": trigger["index"]}, True
+
+    @app.callback(
+        Output("dash-card-header", "children"),
+        Output("dash-card-body", "children"),
+        Output("dash-card-footer", "children"),
+        Input("dashboard-detail", "data"),
+        State("view-as-person", "data"),
+        prevent_initial_call=True,
+    )
+    def render_card(detail, view_as):
+        if not detail:
+            return no_update, no_update, no_update
+        # Same rule as the page: hide write affordances while impersonating.
+        read_only = bool(view_as) and _is_admin()
+        return _render_card(detail["kind"], detail["id"], read_only)
+
+    # -----------------------------------------------------
+    # Handoffs — the dashboard never edits anything itself
+    # -----------------------------------------------------
+    @app.callback(
+        Output("filter-target-entity", "value", allow_duplicate=True),
+        Output("page-store", "data", allow_duplicate=True),
+        Output("output-tabs", "active_tab", allow_duplicate=True),
+        Output("dashboard-detail-modal", "is_open", allow_duplicate=True),
+        Input({"type": "dash-card-explore", "kind": ALL, "index": ALL}, "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def goto_explore(clicks):
+        """Re-centre Explore's existing ego-graph on whatever the card is showing."""
+        trigger = ctx.triggered_id
+        if not isinstance(trigger, dict) or not ctx.triggered[0]["value"]:
+            return no_update, no_update, no_update, no_update
+        return [f"{trigger['kind']}-{trigger['index']}"], "explore", "tab-graph", False
+
+    @app.callback(
+        Output("url", "hash", allow_duplicate=True),
+        Output("dashboard-detail-modal", "is_open", allow_duplicate=True),
+        Input({"type": "dash-card-edit", "kind": ALL, "index": ALL}, "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def edit_from_card(clicks):
+        """Hand the record to the existing generic editor via its #edit route."""
+        trigger = ctx.triggered_id
+        if not isinstance(trigger, dict) or not ctx.triggered[0]["value"]:
+            return no_update, no_update
+        return f"#edit/{trigger['kind']}/{trigger['index']}", False
+
+    @app.callback(
+        Output("table-selector", "value", allow_duplicate=True),
+        Output("form-prefill", "data", allow_duplicate=True),
+        Output("add-dropdown-container", "style", allow_duplicate=True),
+        Output("dashboard-detail-modal", "is_open", allow_duplicate=True),
+        Input({"type": "dash-add-activity", "index": ALL, "slot": ALL}, "n_clicks"),
+        Input("btn-add-activity", "n_clicks"),
+        Input("btn-add-initiative", "n_clicks"),
+        Input({"type": "dash-empty-add-activity", "slot": ALL}, "n_clicks"),
+        State("current-person-id", "data"),
+        prevent_initial_call=True,
+    )
+    def add_from_dashboard(add_activity_for, _activity, _initiative, _empty_add, person_id):
+        """
+        Open the generic add form for a new record.
+
+        From an initiative, the new activity arrives already linked to it, which
+        is why this is "Add activity" rather than a link form: creating the work
+        you just did is the common case, and the link comes free. When you're
+        adding an activity we also link you to it up front — recording your own
+        work is the whole purpose of the page, so you shouldn't have to find your
+        own name in a dropdown every time.
+
+        The prefill carries the editor title; set_editor_title renders it.
+        """
+        trigger = ctx.triggered_id
+        if not ctx.triggered[0]["value"]:
+            return no_update, no_update, no_update, no_update
+
+        hide_dropdown = {"display": "none"}
+
+        def activity_prefill(initiative_id=None):
+            values = {}
+            title = "Add activity"
+            if initiative_id is not None:
+                values["initiatives_links"] = [initiative_id]
+                name = initiative_name(initiative_id)
+                if name:
+                    title = f"Add activity to {name}"
+            if person_id is not None:
+                values["people_links"] = [person_id]
+            return {"table": "activities", "values": values, "title": title}
+
+        kind = trigger.get("type") if isinstance(trigger, dict) else trigger
+        if kind in ("btn-add-activity", "dash-empty-add-activity"):
+            return "activities", activity_prefill(), hide_dropdown, no_update
+        if kind == "btn-add-initiative":
+            return "initiatives", {"table": "initiatives", "values": {}, "title": "Add initiative"}, hide_dropdown, no_update
+        if kind == "dash-add-activity":
+            return "activities", activity_prefill(trigger["index"]), hide_dropdown, False
+        return no_update, no_update, no_update, no_update
+
+    @app.callback(
+        Output("url", "hash", allow_duplicate=True),
+        Output("dashboard-detail-modal", "is_open", allow_duplicate=True),
+        Input({"type": "dash-link-initiative", "index": ALL, "slot": ALL}, "n_clicks"),
+        Input({"type": "dash-add-self", "index": ALL, "slot": ALL}, "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def edit_activity_links(link_initiative, add_self):
+        """
+        Both of these amend an existing activity, so open that activity's own
+        form: it already carries Linked Initiatives and Linked People.
+        """
+        trigger = ctx.triggered_id
+        if not isinstance(trigger, dict) or not ctx.triggered[0]["value"]:
+            return no_update, no_update
+        return f"#edit/activities/{trigger['index']}", False
+
+    @app.callback(
+        Output("form-prefill", "data", allow_duplicate=True),
+        Input("editor-popup", "is_open"),
+        prevent_initial_call=True,
+    )
+    def clear_prefill_on_close(is_open):
+        """A prefill request lasts exactly as long as the editor it opened."""
+        if is_open:
+            return no_update
+        return None

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,14 @@
 title: Collaboratorium
 editor_layout: 'modal' # Options: 'modal' (default), 'sidebar' (drawer), 'inline' (legacy fixed side layout)
+dashboard:
+  # The dashboard is a rolling recency prompt, not a report: the annual report
+  # is the Report tab's job. Windows are in days.
+  default_window_days: 90
+  window_options_days: [30, 90]
+  # 'Nothing recorded in a while' is Mine-only and self-directed. Set false to
+  # remove it from the deployment entirely; each person can also hide it on
+  # their own page, which is remembered in their browser.
+  show_quiet_box: true
 node_tables:
 - activities
 - contracts

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,6 +23,14 @@ OTHERS_ACTIVITY = "Seeded Activity By Someone Else"
 INVOLVED_NOT_OWNED = "Seeded Involved But Not Responsible"
 NEAR_VIA_INVOLVEMENT = "Seeded Near Via Involvement"
 
+# Shared by the fixture and the tests that assert on seeded dates.
+_NOW = datetime.datetime.now()
+RECENT = (_NOW - datetime.timedelta(days=5)).isoformat()
+OLD = (_NOW - datetime.timedelta(days=200)).isoformat()
+# Newer than RECENT: used only for the someone-else activity on the
+# involved-but-not-owned initiative, so its date can't be mistaken for mine.
+NEWER = (_NOW - datetime.timedelta(days=1)).isoformat()
+
 
 @pytest.fixture(scope="module", autouse=True)
 def dashboard_rows(live_server):
@@ -32,9 +40,8 @@ def dashboard_rows(live_server):
     The session database is shared, and other suites assert on exact row counts,
     so anything added here has to be taken back out.
     """
-    now = datetime.datetime.now()
-    recent = (now - datetime.timedelta(days=5)).isoformat()
-    old = (now - datetime.timedelta(days=200)).isoformat()
+    recent = RECENT
+    old = OLD
 
     conn = sqlite3.connect(TEST_DB)
     cur = conn.cursor()
@@ -108,12 +115,12 @@ def dashboard_rows(live_server):
     cur.execute(
         "INSERT INTO activities (id, version, name, status, timestamp, created_by)"
         " VALUES (905, 1, ?, 'active', ?, 2)",
-        (NEAR_VIA_INVOLVEMENT, recent),
+        (NEAR_VIA_INVOLVEMENT, NEWER),
     )
     cur.execute(
         "INSERT INTO activity_initiative_links (id, version, activity_id, initiative_id, status, timestamp, created_by)"
         " VALUES (905, 1, 905, 904, 'active', ?, 2)",
-        (recent,),
+        (NEWER,),
     )
     conn.commit()
     conn.close()
@@ -172,6 +179,23 @@ def test_shared_activity_produces_unique_open_ids():
     assert len(open_ids) == 4, open_ids
     serialized = [tuple(sorted(i.items())) for i in open_ids]
     assert len(set(serialized)) == len(serialized), f"duplicate dash-open ids: {open_ids}"
+
+
+def test_involved_only_feed_date_follows_my_activity():
+    """
+    On an initiative I only contribute to, a later activity by someone else must
+    not float it up the feed under their date. The sort/header date should track
+    the activity actually shown — mine (RECENT), not the newer one (NEWER).
+    """
+    from dashboard_data import recently_updated
+
+    feed = recently_updated(person_id=1, window_days=90)
+    row = next(r for r in feed if r["id"] == 904)
+    assert row["involved_only"], "904 is not owned by me, so it's involved-only"
+    assert row["last_touched"] == RECENT, (
+        f"expected my activity's date, got {row['last_touched']} "
+        f"(the newer someone-else activity was {NEWER})"
+    )
 
 
 def _dashboard(page: Page):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -130,6 +130,50 @@ def dashboard_rows(live_server):
     conn.close()
 
 
+def _collect_ids(node, out):
+    """Walk a Dash component tree collecting every dict-shaped component id."""
+    cid = getattr(node, "id", None)
+    if isinstance(cid, dict):
+        out.append(cid)
+    children = getattr(node, "children", None)
+    if isinstance(children, (list, tuple)):
+        for child in children:
+            _collect_ids(child, out)
+    elif children is not None and not isinstance(children, (str, int, float, bool)):
+        _collect_ids(children, out)
+
+
+def test_shared_activity_produces_unique_open_ids():
+    """
+    An activity linked to several initiatives renders once under each. Their
+    "dash-open" ids must stay distinct: Dash silently stops dispatching a
+    pattern-matching callback when two components share an id, which is the bug
+    the per-render slot exists to prevent. This is the case _open_card's .first
+    would mask, so it is asserted directly here.
+    """
+    from views.tab_dashboard import _render_recent
+
+    event = {
+        "activity_id": 7, "activity_name": "Shared Activity",
+        "actor_name": "Someone", "verb": "updated", "timestamp": "2026-01-01",
+    }
+    initiatives = [
+        {"id": 1, "name": "Init A", "events": [event], "activity_count": 1,
+         "responsible_person": 1, "responsible_name": "Me", "last_touched": "2026-01-01"},
+        {"id": 2, "name": "Init B", "events": [event], "activity_count": 1,
+         "responsible_person": 1, "responsible_name": "Me", "last_touched": "2026-01-01"},
+    ]
+
+    ids = []
+    _collect_ids(_render_recent(initiatives, scope="mine", person_id=1), ids)
+    open_ids = [i for i in ids if i.get("type") == "dash-open"]
+
+    # Two initiative links + the shared activity under each = four links.
+    assert len(open_ids) == 4, open_ids
+    serialized = [tuple(sorted(i.items())) for i in open_ids]
+    assert len(set(serialized)) == len(serialized), f"duplicate dash-open ids: {open_ids}"
+
+
 def _dashboard(page: Page):
     page.goto("http://localhost:8055")
     expect(page.locator("#dashboard-page")).to_be_visible()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,406 @@
+"""
+Dashboard page tests.
+
+The session fixture seeds person 1 (Automated Tester) as responsible for
+Initiative 1 and linked to Activities 1-3, which covers the feed. The extra
+rows seeded here cover the gap-spotting sections, which are the point of the
+page: an initiative with nothing linked, an old one, and a loose activity.
+"""
+import datetime
+import re
+import sqlite3
+
+import pytest
+from playwright.sync_api import Page, expect
+
+TEST_DB = "test_database.db"
+
+NEW_EMPTY = "Seeded New Empty Initiative"
+OLD_EMPTY = "Seeded Quiet Initiative"
+ORPHAN_INITIATIVE = "Seeded Ownerless Initiative"
+LOOSE_ACTIVITY = "Seeded Unlinked Activity"
+OTHERS_ACTIVITY = "Seeded Activity By Someone Else"
+INVOLVED_NOT_OWNED = "Seeded Involved But Not Responsible"
+NEAR_VIA_INVOLVEMENT = "Seeded Near Via Involvement"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def dashboard_rows(live_server):
+    """
+    Seed the cases the base fixture has no examples of, then remove them again.
+
+    The session database is shared, and other suites assert on exact row counts,
+    so anything added here has to be taken back out.
+    """
+    now = datetime.datetime.now()
+    recent = (now - datetime.timedelta(days=5)).isoformat()
+    old = (now - datetime.timedelta(days=200)).isoformat()
+
+    conn = sqlite3.connect(TEST_DB)
+    cur = conn.cursor()
+
+    # Created inside the window, nothing linked -> "New — no activity yet"
+    cur.execute(
+        "INSERT INTO initiatives (id, version, name, status, timestamp, created_by, responsible_person)"
+        " VALUES (901, 1, ?, 'active', ?, 1, 1)",
+        (NEW_EMPTY, recent),
+    )
+    # Created before the window, nothing linked -> "Nothing recorded in a while"
+    cur.execute(
+        "INSERT INTO initiatives (id, version, name, status, timestamp, created_by, responsible_person)"
+        " VALUES (902, 1, ?, 'active', ?, 1, 1)",
+        (OLD_EMPTY, old),
+    )
+    # Created by me, nobody responsible -> Mine via the orphan fallback
+    cur.execute(
+        "INSERT INTO initiatives (id, version, name, status, timestamp, created_by, responsible_person)"
+        " VALUES (903, 1, ?, 'active', ?, 1, NULL)",
+        (ORPHAN_INITIATIVE, recent),
+    )
+    # An activity I'm on that hangs off no initiative
+    cur.execute(
+        "INSERT INTO activities (id, version, name, status, timestamp, created_by)"
+        " VALUES (901, 1, ?, 'active', ?, 1)",
+        (LOOSE_ACTIVITY, recent),
+    )
+    cur.execute(
+        "INSERT INTO activity_people_links (id, version, activity_id, person_id, status, timestamp, created_by)"
+        " VALUES (901, 1, 901, 1, 'active', ?, 1)",
+        (recent,),
+    )
+    # Someone else recorded this against Initiative 1, which I'm responsible for,
+    # and I am not linked to it -> "Touching your work"
+    cur.execute(
+        "INSERT INTO activities (id, version, name, status, timestamp, created_by)"
+        " VALUES (902, 1, ?, 'active', ?, 2)",
+        (OTHERS_ACTIVITY, recent),
+    )
+    cur.execute(
+        "INSERT INTO activity_initiative_links (id, version, activity_id, initiative_id, status, timestamp, created_by)"
+        " VALUES (902, 1, 902, 1, 'active', ?, 2)",
+        (recent,),
+    )
+    # An initiative someone else is responsible for, that is Mine only because I'm
+    # on one of its activities. Must NOT claim "You're responsible".
+    cur.execute(
+        "INSERT INTO initiatives (id, version, name, status, timestamp, created_by, responsible_person)"
+        " VALUES (904, 1, ?, 'active', ?, 2, 2)",
+        (INVOLVED_NOT_OWNED, recent),
+    )
+    cur.execute(
+        "INSERT INTO activities (id, version, name, status, timestamp, created_by)"
+        " VALUES (903, 1, 'Activity I helped with', 'active', ?, 1)",
+        (recent,),
+    )
+    cur.execute(
+        "INSERT INTO activity_people_links (id, version, activity_id, person_id, status, timestamp, created_by)"
+        " VALUES (903, 1, 903, 1, 'active', ?, 1)",
+        (recent,),
+    )
+    cur.execute(
+        "INSERT INTO activity_initiative_links (id, version, activity_id, initiative_id, status, timestamp, created_by)"
+        " VALUES (903, 1, 903, 904, 'active', ?, 1)",
+        (recent,),
+    )
+    # Someone else's activity on that same involved-in-but-not-owned initiative,
+    # which I'm not on -> must surface in "Near Your Work" under the broadened
+    # rule (it would not under the old responsible-for-only rule).
+    cur.execute(
+        "INSERT INTO activities (id, version, name, status, timestamp, created_by)"
+        " VALUES (905, 1, ?, 'active', ?, 2)",
+        (NEAR_VIA_INVOLVEMENT, recent),
+    )
+    cur.execute(
+        "INSERT INTO activity_initiative_links (id, version, activity_id, initiative_id, status, timestamp, created_by)"
+        " VALUES (905, 1, 905, 904, 'active', ?, 2)",
+        (recent,),
+    )
+    conn.commit()
+    conn.close()
+
+    yield
+
+    conn = sqlite3.connect(TEST_DB)
+    cur = conn.cursor()
+    cur.execute("DELETE FROM initiatives WHERE id IN (901, 902, 903, 904)")
+    cur.execute("DELETE FROM activities WHERE id IN (901, 902, 903, 905)")
+    cur.execute("DELETE FROM activity_people_links WHERE id IN (901, 903)")
+    cur.execute("DELETE FROM activity_initiative_links WHERE id IN (902, 903, 905)")
+    conn.commit()
+    conn.close()
+
+
+def _dashboard(page: Page):
+    page.goto("http://localhost:8055")
+    expect(page.locator("#dashboard-page")).to_be_visible()
+    # The body arrives by callback; without waiting for it a click can land
+    # before Dash has attached its handlers.
+    expect(page.locator("#dashboard-body .dash-panel").first).to_be_visible()
+    return page
+
+
+def _open_card(page: Page, name: str):
+    """
+    Click an entity link in the dashboard body.
+
+    Scoped to the anchor and to #dashboard-body on purpose: the hidden Explore
+    spreadsheet also holds cells with these names, so a bare get_by_text is
+    ambiguous.
+    """
+    page.locator("#dashboard-body a.dash-entity-link").filter(
+        has_text=re.compile(rf"^{re.escape(name)}$")
+    ).first.click()
+    card = page.locator("#dashboard-detail-modal")
+    expect(card).to_be_visible()
+    return card
+
+
+def test_dashboard_is_the_landing_page(page: Page):
+    _dashboard(page)
+    expect(page.locator("#explore-container")).to_be_hidden()
+    expect(page.locator("#nav-dashboard")).to_have_class(re.compile(r"\bactive\b"))
+
+
+def test_mine_shows_my_feed_and_gaps(page: Page):
+    _dashboard(page)
+    body = page.locator("#dashboard-body")
+
+    # Feed: the initiative I'm responsible for, with its activities beneath it
+    expect(body).to_contain_text("Initiative 1")
+    expect(body).to_contain_text("You're responsible")
+
+    # Gap-spotting sections
+    expect(body).to_contain_text("New — no activity yet")
+    expect(body).to_contain_text(NEW_EMPTY)
+    expect(body).to_contain_text("Nothing recorded in a while")
+    expect(body).to_contain_text(OLD_EMPTY)
+    expect(body).to_contain_text("Not linked to an initiative")
+    expect(body).to_contain_text(LOOSE_ACTIVITY)
+
+
+def test_involvement_is_not_labelled_as_responsibility(page: Page):
+    """An initiative that's Mine via an activity link isn't claimed as yours to own."""
+    _dashboard(page)
+    item = page.locator(".dash-repo", has_text=INVOLVED_NOT_OWNED)
+    expect(item).to_be_visible()
+    expect(item).not_to_contain_text("You're responsible")
+    expect(item).to_contain_text("Person 2 responsible")
+
+
+def test_orphan_initiative_counts_as_mine(page: Page):
+    """created_by only qualifies where nobody is responsible."""
+    _dashboard(page)
+    expect(page.locator("#dashboard-body")).to_contain_text(ORPHAN_INITIATIVE)
+
+
+def test_near_your_work_shows_owned_by_default_hides_involved(page: Page):
+    _dashboard(page)
+    body = page.locator("#dashboard-body")
+    expect(body).to_contain_text("Near Your Work")
+    # On an initiative I own, shown by default...
+    expect(body).to_contain_text(OTHERS_ACTIVITY)
+    # ...but activity on one I'm only involved in stays behind the toggle, so one
+    # incidental link can't flood the section.
+    expect(body).not_to_contain_text(NEAR_VIA_INVOLVEMENT)
+
+
+def test_near_your_work_toggle_reveals_involved(page: Page):
+    _dashboard(page)
+    body = page.locator("#dashboard-body")
+    expect(body).not_to_contain_text(NEAR_VIA_INVOLVEMENT)
+
+    body.get_by_text("from initiatives you've contributed to").click()
+    expect(body).to_contain_text(NEAR_VIA_INVOLVEMENT)
+
+    # Collapsing hides it again (the preference is remembered per-person).
+    body.get_by_text("Show less", exact=True).click()
+    expect(body).not_to_contain_text(NEAR_VIA_INVOLVEMENT)
+
+
+def test_quiet_box_is_mine_only(page: Page):
+    """Everyone must never become a report on other people's quiet projects."""
+    _dashboard(page)
+    expect(page.locator("#dashboard-body")).to_contain_text("Nothing recorded in a while")
+
+    page.locator("#dash-scope-everyone").click()
+    body = page.locator("#dashboard-body")
+    expect(body).not_to_contain_text("Nothing recorded in a while")
+    expect(body).not_to_contain_text("Near Your Work")
+    # The same feed is still there, just unfiltered
+    expect(body).to_contain_text("Recently updated")
+
+
+def test_quiet_box_hides_and_comes_back(page: Page):
+    _dashboard(page)
+    body = page.locator("#dashboard-body")
+    expect(body).to_contain_text(OLD_EMPTY)
+
+    page.locator('[id*="dash-quiet-toggle"]').first.click()
+    expect(body).to_contain_text("hidden")
+    expect(body).not_to_contain_text(OLD_EMPTY)
+
+    page.get_by_text("Show", exact=True).click()
+    expect(body).to_contain_text(OLD_EMPTY)
+
+
+def test_clicking_an_initiative_opens_its_detail_card(page: Page):
+    _dashboard(page)
+    card = _open_card(page, "Initiative 1")
+
+    expect(card).to_contain_text("Initiative 1")
+    expect(card).to_contain_text("Responsible")
+    # Its activities are listed, and are themselves inspectable
+    expect(card).to_contain_text("Activity 1")
+    # We stay on the dashboard: the card replaced the jump to the graph
+    expect(page.locator("#explore-container")).to_be_hidden()
+
+
+def test_activities_are_inspectable(page: Page):
+    _dashboard(page)
+    card = _open_card(page, "Activity 1")
+
+    expect(card).to_contain_text("Activity 1")
+    expect(card).to_contain_text("Part of")
+    expect(card).to_contain_text("Initiative 1")
+
+
+def test_card_navigates_between_linked_records(page: Page):
+    """An initiative card lists its activities; clicking one swaps the card."""
+    _dashboard(page)
+    card = _open_card(page, "Initiative 1")
+
+    card.locator("a.dash-entity-link").filter(
+        has_text=re.compile(r"^Activity 2$")
+    ).first.click()
+    expect(page.locator("#dash-card-header")).to_contain_text("Activity 2")
+    expect(card).to_contain_text("Part of")
+
+
+def test_card_hands_off_to_explore(page: Page):
+    _dashboard(page)
+    _open_card(page, "Initiative 1")
+
+    page.locator('[id*="dash-card-explore"]').click()
+
+    expect(page.locator("#explore-container")).to_be_visible()
+    expect(page.locator("#dashboard-page")).to_be_hidden()
+    expect(page.locator("#filter-target-entity")).to_contain_text("Initiative 1")
+
+
+def test_header_quick_add_buttons_skip_the_table_dropdown(page: Page):
+    _dashboard(page)
+
+    page.locator("#btn-add-activity").click()
+    editor = page.locator("#editor-popup")
+    expect(editor).to_be_visible()
+    expect(page.locator("#form-heading")).to_contain_text("Add activity")
+    # The table has already been chosen, so its dropdown is out of the way
+    expect(page.locator("#add-dropdown-container")).to_be_hidden()
+
+    page.reload()
+    expect(page.locator("#dashboard-page")).to_be_visible()
+    page.locator("#btn-add-initiative").click()
+    expect(page.locator("#form-heading")).to_contain_text("Add initiative")
+
+
+def test_add_activity_arrives_linked_to_its_initiative(page: Page):
+    """The prefill is the point: the new activity is already linked."""
+    _dashboard(page)
+
+    page.locator('[id*="dash-add-activity"]').first.click()
+    editor = page.locator("#editor-popup")
+    expect(editor).to_be_visible()
+    expect(page.locator("#form-heading")).to_contain_text("Add activity")
+    # Linked Initiatives comes pre-filled with the initiative we started from
+    linked = editor.locator('[id*="initiatives_links"]').first
+    expect(linked).to_contain_text(NEW_EMPTY)
+    # ...and Linked People comes pre-filled with me, so recording my own work
+    # doesn't cost a search for my own name.
+    people = editor.locator('[id*="people_links"]').first
+    expect(people).to_contain_text("Automated Tester")
+
+
+def test_add_activity_editor_names_the_initiative(page: Page):
+    """The header says what's being added and into what, not a bare 'Editor'."""
+    _dashboard(page)
+
+    # Target NEW_EMPTY's own rail card so the title is unambiguous.
+    card = page.locator(".dash-item", has_text=NEW_EMPTY)
+    card.locator('[id*="dash-add-activity"]').click()
+    expect(page.locator("#editor-popup")).to_be_visible()
+    # The heading lives in the form DOM (set when the form renders), so it's
+    # deterministic rather than a racy separate callback.
+    expect(page.locator("#form-heading")).to_contain_text(f"Add activity to {NEW_EMPTY}")
+
+
+def test_header_add_activity_prefills_me_without_an_initiative(page: Page):
+    _dashboard(page)
+
+    page.locator("#btn-add-activity").click()
+    editor = page.locator("#editor-popup")
+    expect(editor).to_be_visible()
+    expect(editor.locator('[id*="people_links"]').first).to_contain_text("Automated Tester")
+    # No initiative context here, so the heading is the generic add label.
+    expect(page.locator("#form-heading")).to_contain_text("Add activity")
+
+
+def test_prefill_does_not_leak_into_a_later_add(page: Page):
+    """A prefill request lasts only as long as the editor it opened."""
+    _dashboard(page)
+
+    page.locator('[id*="dash-add-activity"]').first.click()
+    editor = page.locator("#editor-popup")
+    expect(editor.locator('[id*="initiatives_links"]').first).to_contain_text(NEW_EMPTY)
+
+    page.keyboard.press("Escape")
+    expect(editor).to_be_hidden()
+
+    page.locator("#btn-add-activity").click()
+    expect(editor).to_be_visible()
+    expect(editor.locator('[id*="initiatives_links"]').first).not_to_contain_text(NEW_EMPTY)
+
+
+def test_card_edit_opens_the_generic_editor(page: Page):
+    _dashboard(page)
+    _open_card(page, "Initiative 1")
+
+    page.locator('[id*="dash-card-edit"]').click()
+
+    expect(page.locator("#editor-popup")).to_be_visible()
+    expect(page.locator("#dashboard-detail-modal")).to_be_hidden()
+
+
+def test_view_as_control_is_hidden_for_non_admins(page: Page):
+    _dashboard(page)
+    expect(page.locator("#view-as-container")).to_be_hidden()
+
+
+def test_admin_can_view_another_users_dashboard_read_only(page: Page, monkeypatch):
+    """Admin 'view as' shows that person's dashboard with write affordances gone."""
+    import admin_routes
+
+    # The live server runs in this same process, so patching the module global
+    # makes the dev user (Automated Tester) an admin for this test.
+    monkeypatch.setattr(admin_routes, "ADMIN_EMAILS", ["testrunner@idems.international"])
+
+    _dashboard(page)
+    expect(page.locator("#view-as-container")).to_be_visible()
+
+    # Pick Person 2 (base fixture: responsible for Initiative 2).
+    page.locator("#view-as-pick").click()
+    page.keyboard.type("Person 2", delay=50)
+    page.keyboard.press("Enter")
+
+    banner = page.locator(".dash-viewas-banner")
+    expect(banner).to_contain_text("Viewing as Person 2")
+    expect(banner).to_contain_text("read-only")
+
+    body = page.locator("#dashboard-body")
+    expect(body).to_contain_text("Initiative 2")
+
+    # Write affordances are gone while impersonating.
+    expect(page.locator("#btn-add-activity")).to_be_hidden()
+    expect(page.locator("#btn-add-initiative")).to_be_hidden()
+    _open_card(page, "Initiative 2")
+    expect(page.locator("#dashboard-detail-modal")).to_contain_text("Open in Explore")
+    expect(page.locator('[id*="dash-card-edit"]')).to_have_count(0)

--- a/tests/test_spreadsheet.py
+++ b/tests/test_spreadsheet.py
@@ -40,7 +40,11 @@ STATE_MATRIX = [
 @pytest.mark.parametrize("view_id, tab_name, steps", STATE_MATRIX)
 def test_spreadsheet_pipeline_state_transitions(page: Page, view_id, tab_name, steps):
     page.goto("http://localhost:8055")
-    
+
+    # The app lands on the Dashboard, so reach Explore before driving its filters
+    page.locator("#nav-explore").click()
+    expect(page.locator(f"#{view_id}")).to_be_visible()
+
     # 1. Select the View ONLY if it is not already active to prevent toggling the panel closed
     view_button = page.locator(f"#{view_id}")
     if "btn-warning" not in view_button.get_attribute("class"):


### PR DESCRIPTION
## What

Adds a **Dashboard** page — now the landing page, alongside Explore — that shows a feed of your recently recorded work. It exists to make end-of-year progress reports *proactive*: a place to see what you've actually entered so reports come from real records rather than being reconstructed from memory. It is explicitly **not** surveillance or performance metrics — no per-person scoreboards, no staleness KPIs, no heatmaps.

The page is deliberately rigid: read-only, hand-written SQL. All writes hand off to the existing config-driven generic editor.

## Sections

- **Recent feed** — a rolling 30/90-day view of initiatives you're responsible for or involved in via your own activities. For initiatives you *don't* own, the feed shows **only your own activities**, so one incidental link to someone else's initiative can't flood your view with a co-owner's work.
- **Near Your Work** — activities others recorded near work you own or have contributed to. Rows on initiatives you own show by default; the broader contributed-to set sits behind a per-person **Show more** toggle, remembered in local storage.
- **New without activity**, **Quiet** (can be hidden via config), and **Unlinked activities** boxes.

## Interaction

- Clicking an initiative or activity opens an inline **detail card** (both are inspectable), with **Edit** and **switch to Explore** hand-offs.
- Header gains quick-add **+ Activity** / **+ Initiative** buttons that open the editor prefilled (e.g. a new activity arrives already linked to the initiative you started from).
- Admins (gated by `ADMIN_EMAILS`) can **view the dashboard as another user**, read-only — add/edit affordances are hidden while impersonating. This is UI-level read-only, not a hard server-side write block.

## Notes

- The underlying data visibility model is unchanged — any initiative's activity is still visible org-wide via Explore/Everyone by design. This PR fixes the *dashboard's presentation* so a personal view isn't flooded; it does not add access control on the data itself.
- `TODO.md` captures follow-up items (A–E) surfaced while dogfooding the editor.

## Tests

`tests/test_dashboard.py` added (Playwright-driven): feed scoping, Near Your Work default/toggle behaviour, prefill, admin view-as, and detail cards. Full suite: **28 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
