### PR TITLE
Add conditional form fields: relevant:

### DIFF
--- a/docs/relevance.md
+++ b/docs/relevance.md
@@ -1,0 +1,111 @@
+# Conditional fields: `relevant:`
+
+Show a form element only when a condition over the answers above it holds. The
+motivating case is a records-of-processing checklist, where the lawful basis you
+pick decides which further questions you are legally required to answer:
+
+```yaml
+lawful_basis:
+  type: select_one
+  label: Lawful Basis
+  list_name: basis_list
+  basis_list:
+    consent: Consent
+    legitimate_interest: Legitimate Interest
+
+collection_purpose:
+  type: string
+  label: Collection Purpose
+  relevant: "${lawful_basis} = 'legitimate_interest'"
+```
+
+Adding another conditional field is a config edit. No Python is involved.
+
+## The expression language
+
+Deliberately small, and deliberately not Python `eval` — config is
+operator-supplied and so nominally trusted, but a form dialect that reaches
+`eval` is a landmine for whoever later lets a less-trusted user edit config.
+
+| | |
+| --- | --- |
+| element reference | `${element_name}` |
+| comparison | `=` `!=` `>` `>=` `<` `<=` |
+| multi-select membership | `selected(${tags}, 'health')` |
+| logic | `and` `or` `not`, with parentheses |
+| literals | `'text'`, `"text"`, `42`, `3.14`, `true`, `false`, `null` |
+
+`=` is equality, following ODK, whose conventions this config dialect already
+borrows. `==` is a syntax error.
+
+```yaml
+relevant: "${lawful_basis} = 'consent'"
+relevant: "${retention_years} > 5"
+relevant: "selected(${data_categories}, 'health') or selected(${data_categories}, 'biometric')"
+relevant: "not ${is_internal} and ${country} != 'GB'"
+relevant: "${responsible_person}"          # answered at all
+```
+
+### Semantics worth knowing
+
+**Emptiness is falsehood.** An unanswered question is not a yes: `""`, `[]`,
+`null` and `0` are all false. A bare `${x}` therefore reads as "x has been
+answered". This matches the emptiness test the submit button already uses, so
+"answered" means the same thing to `relevant:` as it does to `required:`.
+
+**Numbers compare numerically even when held as strings.** A `dcc.Input` yields
+a string even for a field the config declares as an integer, so `${n} > 5` is
+true for `"10"`. If either side is not numeric, both are compared as strings.
+
+**A multi-select uses `selected()`.** As a convenience a single-choice
+multi-select compares equal to that choice, but anything longer will not equal a
+scalar. Values are also accepted comma-joined, because that is how they come
+back from the database — an expression behaves the same on an edit form as on an
+add form.
+
+**An unknown element reads as empty, not as an error.** A partially filled form
+would otherwise be unusable. References are checked at startup instead.
+
+## Validation
+
+Every expression is parsed when the app starts, and each name it references is
+checked against the elements of the same form. A mistake stops the deployment
+rather than surfacing later as a field that silently never appears:
+
+```
+pantograph.relevance.FormConfigError: contracts_form.organisation_person:
+  'relevant' references 'organisaton', which is not an element of that form.
+
+pantograph.relevance.FormConfigError: contracts_form.organisation_person:
+  Unexpected '=' at position 17 in '${organisation} === '
+```
+
+Writing `lawful_basis` where you meant `${lawful_basis}` is the likeliest
+authoring slip, so that error names the fix.
+
+## What gets stored
+
+**An answer to a question that no longer applies is stored as NULL.** A record
+claiming a legitimate-interest balancing test when the basis has since been
+changed to Consent would be worse than one that simply does not answer, so a
+stale answer is not kept.
+
+Nothing is lost. The schema is append-only and versioned, so the previous answer
+remains in the record's history — a new version is written with the field
+cleared, and the old version still holds it.
+
+Relevance is recomputed on the server at submit rather than inferred from what
+was on screen. Visibility is a client-side fact and the client is not the
+authority on what gets written.
+
+## Limits
+
+`relevant:` on a **subform** element is rejected at startup rather than silently
+ignored. A subform renders its inputs under its own form namespace, so the
+enclosing form's callback cannot see their state. Supporting it means giving
+subform state a path back to the parent, which is its own piece of work.
+
+Only elements that carry a `relevant:` are wrapped in a container, so a form
+with no conditions renders exactly as it did before, and a form with conditions
+registers exactly one extra callback watching only the elements its conditions
+actually read.

--- a/src/pantograph/app.py
+++ b/src/pantograph/app.py
@@ -18,6 +18,7 @@ from pantograph.db import init_db
 from pantograph.editor import STORE_ID as EDITOR_REQUEST_STORE
 from pantograph.form_gen import register_form_callbacks
 from pantograph.plugins import load_plugins
+from pantograph.relevance import validate_forms
 from pantograph.settings import get_settings
 from pantograph.tools.analysis_report import init_analytics_app
 
@@ -101,6 +102,11 @@ def create_app(settings=None):
     """
     settings = settings or get_settings()
     config = load_config(settings.config_path)
+
+    # Before anything is built: a `relevant:` that cannot be parsed, or that
+    # names an element its form does not define, should stop the deployment
+    # rather than surface later as a field that silently never appears.
+    validate_forms(config)
 
     init_db(config)
     analytics_init_db()

--- a/src/pantograph/expressions.py
+++ b/src/pantograph/expressions.py
@@ -1,0 +1,367 @@
+"""
+expressions.py
+The small expression language used by `relevant:` (and, later, `constraint:`).
+
+Deliberately not Python `eval`. Config is operator-supplied and so nominally
+trusted, but a form dialect that reaches `eval` is a landmine for whoever later
+lets a less-trusted user edit config — and the grammar we actually need is tiny:
+
+    expr       := or_expr
+    or_expr    := and_expr ( 'or' and_expr )*
+    and_expr   := not_expr ( 'and' not_expr )*
+    not_expr   := 'not' not_expr | comparison
+    comparison := primary ( ('=' | '!=' | '>' | '>=' | '<' | '<=') primary )?
+    primary    := '(' expr ')' | 'selected' '(' expr ',' expr ')'
+                | '${' NAME '}' | STRING | NUMBER | 'true' | 'false' | 'null'
+
+Written as a tokeniser plus recursive-descent parser producing an AST, which is
+then evaluated against a mapping of element name to current value. Parsing is
+separated from evaluation so config can be validated at startup — an expression
+that does not parse, or that references an element the form does not define,
+should fail before anyone opens the form.
+
+`=` is used for equality rather than `==`, following ODK, whose conventions this
+config dialect already borrows.
+"""
+import re
+
+
+class ExpressionError(Exception):
+    """Raised for an expression that cannot be tokenised, parsed or resolved."""
+
+
+# --------------------------------------------------------------------------
+# Tokeniser
+# --------------------------------------------------------------------------
+
+# Inner captures are *named*, not positional: positional indices shift
+# whenever a rule is added above them, which is a silent breakage.
+_TOKEN_SPEC = [
+    ("WS",      r"\s+"),
+    ("REF",     r"\$\{\s*(?P<ref_name>[A-Za-z_][A-Za-z0-9_]*)\s*\}"),
+    ("NUMBER",  r"-?\d+\.\d+|-?\d+"),
+    ("STRING",  r"'(?P<sq>[^']*)'|\"(?P<dq>[^\"]*)\""),
+    ("OP",      r"!=|>=|<=|=|>|<"),
+    ("LPAREN",  r"\("),
+    ("RPAREN",  r"\)"),
+    ("COMMA",   r","),
+    ("NAME",    r"[A-Za-z_][A-Za-z0-9_]*"),
+]
+_TOKEN_RE = re.compile("|".join(f"(?P<{name}>{pattern})" for name, pattern in _TOKEN_SPEC))
+
+_KEYWORDS = {"and", "or", "not", "true", "false", "null", "selected"}
+
+
+class _Token:
+    __slots__ = ("kind", "value", "pos")
+
+    def __init__(self, kind, value, pos):
+        self.kind, self.value, self.pos = kind, value, pos
+
+    def __repr__(self):  # pragma: no cover - debugging aid
+        return f"<{self.kind} {self.value!r} @{self.pos}>"
+
+
+def tokenise(source):
+    tokens, pos = [], 0
+    while pos < len(source):
+        match = _TOKEN_RE.match(source, pos)
+        if not match:
+            raise ExpressionError(
+                f"Unexpected character {source[pos]!r} at position {pos} in {source!r}"
+            )
+        kind = match.lastgroup
+        # lastgroup can name an inner capture, so map those back to their rule.
+        if kind == "ref_name":
+            kind = "REF"
+        elif kind in ("sq", "dq"):
+            kind = "STRING"
+        if kind == "WS":
+            pass
+        elif kind == "REF":
+            tokens.append(_Token("REF", match.group("ref_name"), pos))
+        elif kind == "STRING":
+            text = match.group("sq")
+            if text is None:
+                text = match.group("dq")
+            tokens.append(_Token("STRING", text, pos))
+        elif kind == "NAME":
+            word = match.group()
+            if word.lower() in _KEYWORDS:
+                tokens.append(_Token(word.lower().upper(), word.lower(), pos))
+            else:
+                raise ExpressionError(
+                    f"Unknown name {word!r} at position {pos} in {source!r}. "
+                    f"Element references must be written ${{{word}}}."
+                )
+        else:
+            tokens.append(_Token(kind, match.group(), pos))
+        pos = match.end()
+    tokens.append(_Token("EOF", None, len(source)))
+    return tokens
+
+
+# --------------------------------------------------------------------------
+# AST
+# --------------------------------------------------------------------------
+
+class Node:
+    pass
+
+
+class Ref(Node):
+    def __init__(self, name):
+        self.name = name
+
+
+class Literal(Node):
+    def __init__(self, value):
+        self.value = value
+
+
+class Compare(Node):
+    def __init__(self, op, left, right):
+        self.op, self.left, self.right = op, left, right
+
+
+class BoolOp(Node):
+    def __init__(self, op, left, right):
+        self.op, self.left, self.right = op, left, right
+
+
+class Not(Node):
+    def __init__(self, operand):
+        self.operand = operand
+
+
+class Selected(Node):
+    """`selected(${x}, 'v')` — is 'v' among the choices held by x?"""
+
+    def __init__(self, haystack, needle):
+        self.haystack, self.needle = haystack, needle
+
+
+# --------------------------------------------------------------------------
+# Parser
+# --------------------------------------------------------------------------
+
+class _Parser:
+    def __init__(self, tokens, source):
+        self.tokens, self.source, self.i = tokens, source, 0
+
+    @property
+    def current(self):
+        return self.tokens[self.i]
+
+    def _advance(self):
+        token = self.tokens[self.i]
+        self.i += 1
+        return token
+
+    def _expect(self, kind):
+        if self.current.kind != kind:
+            raise ExpressionError(
+                f"Expected {kind} but found {self.current.value!r} at position "
+                f"{self.current.pos} in {self.source!r}"
+            )
+        return self._advance()
+
+    def parse(self):
+        node = self._or()
+        if self.current.kind != "EOF":
+            raise ExpressionError(
+                f"Unexpected {self.current.value!r} at position {self.current.pos} "
+                f"in {self.source!r}"
+            )
+        return node
+
+    def _or(self):
+        node = self._and()
+        while self.current.kind == "OR":
+            self._advance()
+            node = BoolOp("or", node, self._and())
+        return node
+
+    def _and(self):
+        node = self._not()
+        while self.current.kind == "AND":
+            self._advance()
+            node = BoolOp("and", node, self._not())
+        return node
+
+    def _not(self):
+        if self.current.kind == "NOT":
+            self._advance()
+            return Not(self._not())
+        return self._comparison()
+
+    def _comparison(self):
+        left = self._primary()
+        if self.current.kind == "OP":
+            op = self._advance().value
+            return Compare(op, left, self._primary())
+        return left
+
+    def _primary(self):
+        token = self.current
+        if token.kind == "LPAREN":
+            self._advance()
+            node = self._or()
+            self._expect("RPAREN")
+            return node
+        if token.kind == "SELECTED":
+            self._advance()
+            self._expect("LPAREN")
+            haystack = self._or()
+            self._expect("COMMA")
+            needle = self._or()
+            self._expect("RPAREN")
+            return Selected(haystack, needle)
+        if token.kind == "REF":
+            self._advance()
+            return Ref(token.value)
+        if token.kind == "STRING":
+            self._advance()
+            return Literal(token.value)
+        if token.kind == "NUMBER":
+            self._advance()
+            text = token.value
+            return Literal(float(text) if "." in text else int(text))
+        if token.kind in ("TRUE", "FALSE"):
+            self._advance()
+            return Literal(token.kind == "TRUE")
+        if token.kind == "NULL":
+            self._advance()
+            return Literal(None)
+        raise ExpressionError(
+            f"Unexpected {token.value!r} at position {token.pos} in {self.source!r}"
+        )
+
+
+def parse(source):
+    """Parse an expression string into an AST. Raises ExpressionError."""
+    if not isinstance(source, str) or not source.strip():
+        raise ExpressionError(f"Empty expression: {source!r}")
+    return _Parser(tokenise(source), source).parse()
+
+
+def referenced_elements(node):
+    """Every element name an expression reads, for validation and callback wiring."""
+    if isinstance(node, Ref):
+        return {node.name}
+    found = set()
+    for attr in ("left", "right", "operand", "haystack", "needle"):
+        child = getattr(node, attr, None)
+        if isinstance(child, Node):
+            found |= referenced_elements(child)
+    return found
+
+
+# --------------------------------------------------------------------------
+# Evaluation
+# --------------------------------------------------------------------------
+
+def is_truthy(value):
+    """
+    Emptiness is falsehood: an unanswered question is not a yes.
+
+    Mirrors the emptiness test the submit-button validation already uses, so
+    "answered" means the same thing to `relevant:` as it does to `required:`.
+    """
+    if isinstance(value, str):
+        return value.strip() != ""
+    if isinstance(value, (list, tuple, dict, set)):
+        return len(value) > 0
+    return bool(value)
+
+
+def _as_number(value):
+    """Return value as a number, or None if it is not numeric."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        try:
+            return float(value) if "." in value else int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _as_choices(value):
+    """
+    Normalise a select_multiple value to a list of strings.
+
+    Dash hands these over as a list, but the same value read back from the
+    database is comma-joined (see how form_gen writes list values), so both
+    shapes have to work or an expression would behave differently on an edit
+    form than on an add form.
+    """
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [str(v) for v in value]
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    return [str(value)]
+
+
+def _compare(op, left, right):
+    # Numeric when both sides genuinely are; otherwise string. This keeps
+    # "3" = 3 true, which matters because a dcc.Input yields strings even for
+    # a field the config declares as an integer.
+    left_num, right_num = _as_number(left), _as_number(right)
+    if left_num is not None and right_num is not None:
+        left_cmp, right_cmp = left_num, right_num
+    else:
+        if isinstance(left, (list, tuple)) or isinstance(right, (list, tuple)):
+            # A multi-select holding exactly one choice compares as that choice;
+            # otherwise it is not equal to any scalar. Use selected() instead.
+            left = left[0] if isinstance(left, (list, tuple)) and len(left) == 1 else left
+            right = right[0] if isinstance(right, (list, tuple)) and len(right) == 1 else right
+        left_cmp = "" if left is None else str(left)
+        right_cmp = "" if right is None else str(right)
+
+    if op == "=":
+        return left_cmp == right_cmp
+    if op == "!=":
+        return left_cmp != right_cmp
+    try:
+        if op == ">":
+            return left_cmp > right_cmp
+        if op == ">=":
+            return left_cmp >= right_cmp
+        if op == "<":
+            return left_cmp < right_cmp
+        if op == "<=":
+            return left_cmp <= right_cmp
+    except TypeError as exc:  # pragma: no cover - defensive
+        raise ExpressionError(f"Cannot compare {left!r} {op} {right!r}") from exc
+    raise ExpressionError(f"Unknown operator {op!r}")
+
+
+def _value(node, context):
+    """Evaluate a node to a raw value (not yet coerced to a boolean)."""
+    if isinstance(node, Literal):
+        return node.value
+    if isinstance(node, Ref):
+        return context.get(node.name)
+    if isinstance(node, Compare):
+        return _compare(node.op, _value(node.left, context), _value(node.right, context))
+    if isinstance(node, BoolOp):
+        left = is_truthy(_value(node.left, context))
+        if node.op == "and":
+            return left and is_truthy(_value(node.right, context))
+        return left or is_truthy(_value(node.right, context))
+    if isinstance(node, Not):
+        return not is_truthy(_value(node.operand, context))
+    if isinstance(node, Selected):
+        needle = _value(node.needle, context)
+        return str(needle) in _as_choices(_value(node.haystack, context))
+    raise ExpressionError(f"Cannot evaluate node {node!r}")  # pragma: no cover
+
+
+def evaluate(node, context):
+    """Evaluate a parsed expression against {element_name: value} to a bool."""
+    return is_truthy(_value(node, context))

--- a/src/pantograph/form_gen.py
+++ b/src/pantograph/form_gen.py
@@ -7,6 +7,7 @@ import dash_bootstrap_components as dbc
 from pantograph.analytics import analytics_log
 from pantograph.auth import login_required
 from pantograph.component_factory import component_for_element, register_subform_blocks
+from pantograph import relevance
 
 
 # ==============================================================
@@ -46,7 +47,12 @@ def generate_form_layout(form_name, forms_config, object_id=None, initial_values
     for element_name, element_def in forms_config[form_name].get("elements", {}).items():
         val = record_data.get(element_name) if record_data else None
         element_def = {**element_def, "element_id": element_name}
-        elements.append(component_for_element(element_def, form_name=form_name, value=val))
+        component = component_for_element(element_def, form_name=form_name, value=val)
+        if element_def.get("relevant"):
+            # Only conditional elements are wrapped, so nothing about an
+            # existing deployment's DOM changes.
+            component = relevance.wrap(component, form_name, element_name)
+        elements.append(component)
 
     meta_hidden = []
     for element_name, element_def in forms_config[form_name].get("meta", {}).items():
@@ -87,6 +93,7 @@ def register_form_callbacks(app, config):
     register_click_callbacks(app, config)
     register_submit_callbacks(app, config.get("forms", {}))
     register_subform_blocks(app, config.get("forms", {}))
+    relevance.register_relevance_callbacks(app, config.get("forms", {}))
 
 def register_click_callbacks(app, config):
     forms_config = config.get("forms", {})
@@ -300,6 +307,15 @@ def register_submit_callbacks(app, forms_config):
             # Part 1: Handle the main object (Person, Initiative, etc.)
             element_ids = list(_fc["elements"].keys())
             data = dict(zip(element_ids + list(_fc["meta"].keys()), values))
+
+            # An answer to a question that no longer applies is worse than no
+            # answer -- a record claiming a legitimate-interest balancing test
+            # when the basis has since become Consent would be actively
+            # misleading. Recomputed here rather than trusting what the browser
+            # had on screen. Nothing is lost: the schema is append-only, so the
+            # previous answer stays in the record's history.
+            for element_id in relevance.irrelevant_elements(_fc, data):
+                data[element_id] = None
 
             object_id = data.get('id')
             if object_id == "":

--- a/src/pantograph/relevance.py
+++ b/src/pantograph/relevance.py
@@ -1,0 +1,188 @@
+"""
+relevance.py
+`relevant:` on a form element — show it only when its condition holds.
+
+The condition is written in the expression language in `expressions.py`:
+
+    collection_purpose:
+      type: string
+      label: Collection Purpose
+      relevant: "${lawful_basis} = 'legitimate_interest'"
+
+Three moving parts, all here:
+
+1. `validate_forms` parses every expression at startup and checks each name it
+   references is an element of the same form. A form dialect that fails at first
+   click instead of at boot is a bad trade for the person deploying it.
+2. `register_relevance_callbacks` adds one callback per form that toggles the
+   container of each conditional element as the answers it depends on change.
+3. `irrelevant_elements` recomputes the same conditions server-side at submit,
+   because the visibility of a component is a client-side fact and the client is
+   not the authority on what gets written.
+
+**Answers to questions that no longer apply are stored as NULL.** A record
+claiming a legitimate-interest balancing test when the basis has since been
+changed to Consent would be worse than one that simply does not answer. Nothing
+is lost: the schema is append-only and versioned, so the previous answer remains
+in the record's history.
+
+Not in scope yet: `relevant:` *inside* a subform block. Subforms render their
+own inputs under a separate form namespace, so their state is not visible to the
+enclosing form's callback. A `relevant:` there is rejected by `validate_forms`
+rather than silently ignored.
+"""
+from dash import Input, Output, html
+
+from pantograph.expressions import ExpressionError, evaluate, parse, referenced_elements
+
+# How to read the current value of each element type off its component. Mirrors
+# the mapping in form_gen's submit registration; they must agree or an
+# expression would read the wrong property.
+VALUE_KEY = {
+    "date": "date",
+    "datetime": "date",
+    "subform": "data",
+    "table": "data",
+}
+
+VISIBLE = {"display": "block"}
+HIDDEN = {"display": "none"}
+
+
+def value_key(element_config):
+    return VALUE_KEY.get(element_config.get("type"), "value")
+
+
+def container_id(form_name, element_id):
+    return {"type": "relevance", "form": form_name, "element": element_id}
+
+
+def wrap(component, form_name, element_id):
+    """
+    Put a conditional element in an addressable container.
+
+    Wrapping here rather than inside `component_for_element` keeps every element
+    type's rendering untouched — an element with no `relevant:` is not wrapped at
+    all, so nothing about an existing deployment's DOM changes.
+    """
+    return html.Div(component, id=container_id(form_name, element_id))
+
+
+# --------------------------------------------------------------------------
+# Config validation
+# --------------------------------------------------------------------------
+
+class FormConfigError(Exception):
+    """Raised for a form whose `relevant:` expressions cannot be honoured."""
+
+
+def _compiled(form_config):
+    """{element_id: ast} for every element of this form carrying a `relevant:`."""
+    compiled = {}
+    for element_id, element in (form_config.get("elements") or {}).items():
+        expression = element.get("relevant")
+        if expression:
+            compiled[element_id] = parse(expression)
+    return compiled
+
+
+def compile_form(form_name, form_config):
+    """Parse and check one form's expressions. Raises FormConfigError."""
+    elements = form_config.get("elements") or {}
+    known = set(elements) | set(form_config.get("meta") or {})
+
+    compiled = {}
+    for element_id, element in elements.items():
+        expression = element.get("relevant")
+        if not expression:
+            continue
+        if element.get("type") == "subform":
+            raise FormConfigError(
+                f"{form_name}.{element_id}: 'relevant' on a subform element is not "
+                f"supported yet — a subform renders its inputs in its own "
+                f"namespace, so the enclosing form cannot see their state."
+            )
+        try:
+            node = parse(expression)
+        except ExpressionError as exc:
+            raise FormConfigError(f"{form_name}.{element_id}: {exc}") from exc
+
+        unknown = sorted(referenced_elements(node) - known)
+        if unknown:
+            raise FormConfigError(
+                f"{form_name}.{element_id}: 'relevant' references "
+                f"{', '.join(repr(u) for u in unknown)}, which "
+                f"{'is not an element' if len(unknown) == 1 else 'are not elements'} "
+                f"of that form."
+            )
+        compiled[element_id] = node
+    return compiled
+
+
+def validate_forms(config):
+    """
+    Check every form in the config. Called at startup so a bad expression stops
+    the deployment rather than surfacing as a field that never appears.
+    """
+    compiled = {}
+    for form_name, form_config in (config.get("forms") or {}).items():
+        compiled[form_name] = compile_form(form_name, form_config)
+    return compiled
+
+
+# --------------------------------------------------------------------------
+# Evaluation
+# --------------------------------------------------------------------------
+
+def irrelevant_elements(form_config, values):
+    """
+    Which of this form's elements are not currently applicable.
+
+    `values` maps element name to submitted value. Recomputed server-side at
+    submit rather than trusting what the browser had on screen.
+    """
+    hidden = set()
+    for element_id, node in compile_form("<submit>", form_config).items():
+        if not evaluate(node, values):
+            hidden.add(element_id)
+    return hidden
+
+
+def register_relevance_callbacks(app, forms_config):
+    """One callback per form with conditional elements."""
+    for form_name, form_config in (forms_config or {}).items():
+        compiled = compile_form(form_name, form_config)
+        if not compiled:
+            continue
+
+        elements = form_config.get("elements") or {}
+        # Only the elements actually referenced drive the callback; watching
+        # every field would re-run it on every keystroke anywhere in the form.
+        watched = sorted({name for node in compiled.values() for name in referenced_elements(node)})
+        conditional = sorted(compiled)
+
+        inputs = [
+            Input({"type": "input", "form": form_name, "element": name},
+                  value_key(elements.get(name, {})))
+            for name in watched
+        ]
+        outputs = [
+            Output(container_id(form_name, element_id), "style")
+            for element_id in conditional
+        ]
+
+        @app.callback(outputs, inputs, prevent_initial_call=False)
+        def toggle(*current, _compiled=compiled, _watched=watched, _conditional=conditional):
+            return styles_for(_compiled, _watched, _conditional, current)
+
+
+def styles_for(compiled, watched, conditional, current_values):
+    """
+    The callback's whole body, as a plain function so it can be tested without
+    a live app. `current_values` is positional, matching `watched`.
+    """
+    context = dict(zip(watched, current_values))
+    return [
+        VISIBLE if evaluate(compiled[element_id], context) else HIDDEN
+        for element_id in conditional
+    ]

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,0 +1,204 @@
+"""
+The `relevant:` expression language.
+
+Parsing is tested separately from evaluation because config validation at
+startup needs the first without the second — an expression that cannot parse
+should fail before anyone opens the form.
+"""
+import pytest
+
+from pantograph.expressions import (
+    ExpressionError,
+    evaluate,
+    is_truthy,
+    parse,
+    referenced_elements,
+)
+
+
+def ev(source, **context):
+    return evaluate(parse(source), context)
+
+
+# --------------------------------------------------------------------------
+# The motivating case
+# --------------------------------------------------------------------------
+
+LAWFUL_BASIS = "${lawful_basis} = 'legitimate_interest'"
+
+
+def test_the_ropa_lawful_basis_rule():
+    assert ev(LAWFUL_BASIS, lawful_basis="legitimate_interest") is True
+    assert ev(LAWFUL_BASIS, lawful_basis="consent") is False
+    # Unanswered is not a match, rather than an error.
+    assert ev(LAWFUL_BASIS, lawful_basis=None) is False
+    assert ev(LAWFUL_BASIS) is False
+
+
+# --------------------------------------------------------------------------
+# Comparison
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("source, expected", [
+    ("${a} = 'x'", True),
+    ("${a} != 'x'", False),
+    ("${a} = 'y'", False),
+    ("${a} != 'y'", True),
+])
+def test_equality(source, expected):
+    assert ev(source, a="x") is expected
+
+
+def test_numbers_compare_numerically_even_when_held_as_strings():
+    """A dcc.Input yields a string even for a field declared as an integer."""
+    assert ev("${n} > 5", n="10") is True
+    assert ev("${n} > 5", n="10.5") is True
+    assert ev("${n} = 3", n="3") is True
+    assert ev("${n} >= 3 and ${n} <= 5", n=4) is True
+
+
+def test_non_numeric_strings_compare_as_strings():
+    assert ev("${a} = 'apple'", a="apple") is True
+    assert ev("${a} < 'b'", a="a") is True
+
+
+def test_double_and_single_quoted_strings_are_equivalent():
+    assert ev('${a} = "x"', a="x") is True
+
+
+def test_missing_element_reads_as_empty_not_an_error():
+    """
+    A form can legitimately reference an element that has not been answered.
+    Erroring would make a partially filled form unusable.
+    """
+    assert ev("${nope} = ''") is True
+    assert ev("${nope}") is False
+
+
+# --------------------------------------------------------------------------
+# Booleans and truthiness
+# --------------------------------------------------------------------------
+
+def test_and_or_not():
+    assert ev("${a} = '1' and ${b} = '2'", a="1", b="2") is True
+    assert ev("${a} = '1' and ${b} = '2'", a="1", b="9") is False
+    assert ev("${a} = '1' or ${b} = '2'", a="9", b="2") is True
+    assert ev("not ${a} = '1'", a="9") is True
+
+
+def test_parentheses_override_precedence():
+    ctx = dict(a="1", b="0", c="1")
+    # and binds tighter than or, so without parentheses this is a or (b and c)
+    assert ev("${a} = '1' or ${b} = '1' and ${c} = '1'", **ctx) is True
+    assert ev("(${a} = '1' or ${b} = '1') and ${c} = '1'", **ctx) is True
+    assert ev("(${b} = '1' or ${a} = '9') and ${c} = '1'", **ctx) is False
+
+
+def test_a_bare_reference_is_an_answered_test():
+    assert ev("${a}", a="something") is True
+    assert ev("${a}", a="") is False
+    assert ev("${a}", a="   ") is False
+    assert ev("${a}", a=[]) is False
+    assert ev("${a}", a=["x"]) is True
+    assert ev("${a}", a=0) is False
+
+
+@pytest.mark.parametrize("value, expected", [
+    ("", False), ("  ", False), ("x", True),
+    ([], False), (["a"], True), ({}, False),
+    (None, False), (0, False), (1, True), (False, False), (True, True),
+])
+def test_emptiness_is_falsehood(value, expected):
+    """Matches the emptiness test the submit-button validation already uses."""
+    assert is_truthy(value) is expected
+
+
+# --------------------------------------------------------------------------
+# selected(), for select_multiple
+# --------------------------------------------------------------------------
+
+def test_selected_over_a_list():
+    assert ev("selected(${tags}, 'health')", tags=["health", "climate"]) is True
+    assert ev("selected(${tags}, 'nope')", tags=["health", "climate"]) is False
+    assert ev("selected(${tags}, 'health')", tags=[]) is False
+    assert ev("selected(${tags}, 'health')", tags=None) is False
+
+
+def test_selected_over_a_comma_joined_string():
+    """
+    The same value read back from the database is comma-joined, so an
+    expression must behave the same on an edit form as on an add form.
+    """
+    assert ev("selected(${tags}, 'climate')", tags="health,climate") is True
+    assert ev("selected(${tags}, 'climate')", tags="health, climate") is True
+    assert ev("selected(${tags}, 'nope')", tags="health,climate") is False
+
+
+def test_a_single_choice_multiselect_compares_as_that_choice():
+    """Convenience; anything longer must use selected()."""
+    assert ev("${tags} = 'health'", tags=["health"]) is True
+    assert ev("${tags} = 'health'", tags=["health", "climate"]) is False
+
+
+# --------------------------------------------------------------------------
+# Parsing and validation
+# --------------------------------------------------------------------------
+
+def test_referenced_elements_finds_every_name():
+    node = parse("${a} = '1' and (not ${b}) or selected(${c}, ${d})")
+    assert referenced_elements(node) == {"a", "b", "c", "d"}
+
+
+@pytest.mark.parametrize("source", [
+    "",
+    "   ",
+    "${a} =",
+    "= '1'",
+    "${a} = 'unterminated",
+    "(${a} = '1'",
+    "${a} = '1')",
+    "selected(${a})",
+    "selected(${a}, 'b'",
+    "${a} == '1'",       # '=' is the operator, following ODK
+    "${a} & ${b}",
+    "@",
+])
+def test_malformed_expressions_are_rejected(source):
+    with pytest.raises(ExpressionError):
+        parse(source)
+
+
+def test_a_bare_word_is_rejected_and_says_how_to_reference_an_element():
+    """
+    The likeliest authoring mistake is writing `lawful_basis` for
+    `${lawful_basis}`, so the message should name the fix.
+    """
+    with pytest.raises(ExpressionError, match=r"\$\{lawful_basis\}"):
+        parse("lawful_basis = 'consent'")
+
+
+def test_errors_locate_themselves_in_the_source():
+    with pytest.raises(ExpressionError, match="position"):
+        parse("${a} = = '1'")
+
+
+def test_literals_parse():
+    assert ev("true") is True
+    assert ev("false") is False
+    assert ev("null") is False
+    assert ev("${a} = null", a=None) is True
+
+
+def test_there_is_no_way_to_reach_python():
+    """
+    The reason this is a parser and not eval(). These are all rejected as
+    unknown names or bad syntax rather than executed.
+    """
+    for source in [
+        "__import__('os').system('echo pwned')",
+        "().__class__.__bases__",
+        "${a}.__class__",
+        "exec('x=1')",
+    ]:
+        with pytest.raises(ExpressionError):
+            parse(source)

--- a/tests/test_relevance.py
+++ b/tests/test_relevance.py
@@ -1,0 +1,270 @@
+"""
+`relevant:` on form elements: validation, toggling, and what gets stored.
+
+The form under test is defined here as config only — no Python is written to
+make its conditional fields work, which is the point of the feature.
+"""
+import json
+
+import pytest
+from dash import Dash
+
+from pantograph import relevance
+from pantograph.form_gen import generate_form_layout
+from pantograph.relevance import (
+    FormConfigError,
+    HIDDEN,
+    VISIBLE,
+    compile_form,
+    irrelevant_elements,
+    register_relevance_callbacks,
+    styles_for,
+    validate_forms,
+)
+
+# A cut-down Record of Processing Activity: the lawful basis you pick decides
+# which further questions you are legally required to answer.
+ROPA_FORM = {
+    "label": "Processing Activity",
+    "default_table": "processing_activities",
+    "elements": {
+        "name": {"type": "string", "label": "Name", "required": True},
+        "lawful_basis": {
+            "type": "select_one", "label": "Lawful Basis", "list_name": "basis_list",
+            "basis_list": {
+                "consent": "Consent",
+                "legitimate_interest": "Legitimate Interest",
+                "legal_obligation": "Legal Obligation",
+            },
+        },
+        "collection_purpose": {
+            "type": "string", "label": "Collection Purpose",
+            "relevant": "${lawful_basis} = 'legitimate_interest'",
+        },
+        "collection_balance": {
+            "type": "string", "label": "Collection Balance",
+            "relevant": "${lawful_basis} = 'legitimate_interest'",
+        },
+        "consent_record": {
+            "type": "string", "label": "How consent is recorded",
+            "relevant": "${lawful_basis} = 'consent'",
+        },
+        "special_category_safeguards": {
+            "type": "string", "label": "Safeguards",
+            "relevant": "selected(${data_categories}, 'health') or selected(${data_categories}, 'biometric')",
+        },
+        "data_categories": {
+            "type": "select_multiple", "label": "Categories", "list_name": "cat_list",
+            "cat_list": {"health": "Health", "biometric": "Biometric", "contact": "Contact"},
+        },
+    },
+    "meta": {"id": {}, "version": {}, "timestamp": {}, "created_by": {}, "status": {}},
+}
+
+FORMS = {"ropa_form": ROPA_FORM}
+
+
+# --------------------------------------------------------------------------
+# Which fields show
+# --------------------------------------------------------------------------
+
+def _styles(**answers):
+    compiled = compile_form("ropa_form", ROPA_FORM)
+    conditional = sorted(compiled)
+    watched = sorted({n for node in compiled.values()
+                      for n in relevance.referenced_elements(node)})
+    values = [answers.get(name) for name in watched]
+    return dict(zip(conditional, styles_for(compiled, watched, conditional, values)))
+
+
+def test_legitimate_interest_reveals_its_three_questions():
+    shown = _styles(lawful_basis="legitimate_interest")
+    assert shown["collection_purpose"] == VISIBLE
+    assert shown["collection_balance"] == VISIBLE
+    assert shown["consent_record"] == HIDDEN
+
+
+def test_consent_reveals_a_different_question():
+    shown = _styles(lawful_basis="consent")
+    assert shown["consent_record"] == VISIBLE
+    assert shown["collection_purpose"] == HIDDEN
+    assert shown["collection_balance"] == HIDDEN
+
+
+def test_an_unanswered_basis_reveals_nothing():
+    shown = _styles()
+    assert all(style == HIDDEN for style in shown.values())
+
+
+def test_a_third_basis_reveals_neither_branch():
+    shown = _styles(lawful_basis="legal_obligation")
+    assert shown["collection_purpose"] == HIDDEN
+    assert shown["consent_record"] == HIDDEN
+
+
+def test_a_multiselect_condition():
+    assert _styles(data_categories=["contact"])["special_category_safeguards"] == HIDDEN
+    assert _styles(data_categories=["contact", "health"])["special_category_safeguards"] == VISIBLE
+    assert _styles(data_categories=["biometric"])["special_category_safeguards"] == VISIBLE
+
+
+def test_adding_a_conditional_field_needs_no_python():
+    """
+    The acceptance criterion, stated directly: a new conditional field is a
+    config edit. This form is defined in this file and nothing imports it.
+    """
+    extended = {**ROPA_FORM, "elements": {
+        **ROPA_FORM["elements"],
+        "retention_justification": {
+            "type": "string", "label": "Why retain this long?",
+            "relevant": "${lawful_basis} != 'consent' and ${lawful_basis}",
+        },
+    }}
+    compiled = compile_form("ropa_form", extended)
+    assert "retention_justification" in compiled
+    node = compiled["retention_justification"]
+    from pantograph.expressions import evaluate
+    assert evaluate(node, {"lawful_basis": "legitimate_interest"}) is True
+    assert evaluate(node, {"lawful_basis": "consent"}) is False
+    assert evaluate(node, {"lawful_basis": None}) is False
+
+
+# --------------------------------------------------------------------------
+# Startup validation
+# --------------------------------------------------------------------------
+
+def test_an_unparseable_expression_names_the_form_and_element():
+    bad = {"f": {"elements": {"a": {"type": "string", "relevant": "${x} ==== "}}, "meta": {}}}
+    with pytest.raises(FormConfigError, match=r"f\.a"):
+        validate_forms({"forms": bad})
+
+
+def test_a_reference_to_a_nonexistent_element_is_rejected():
+    bad = {"f": {"elements": {
+        "a": {"type": "string"},
+        "b": {"type": "string", "relevant": "${typo_here} = '1'"},
+    }, "meta": {}}}
+    with pytest.raises(FormConfigError, match="typo_here"):
+        validate_forms({"forms": bad})
+
+
+def test_a_reference_to_a_meta_element_is_allowed():
+    """`status` and `version` are real values a form can legitimately condition on."""
+    ok = {"f": {"elements": {"a": {"type": "string", "relevant": "${status} = 'active'"}},
+                "meta": {"status": {}}}}
+    assert validate_forms({"forms": ok})["f"]
+
+
+def test_relevant_on_a_subform_is_rejected_rather_than_silently_ignored():
+    """
+    Out of scope for now: a subform renders its inputs in its own namespace, so
+    the enclosing form's callback cannot see their state. Failing loudly beats a
+    condition that never fires.
+    """
+    bad = {"f": {"elements": {
+        "a": {"type": "string"},
+        "s": {"type": "subform", "relevant": "${a} = '1'"},
+    }, "meta": {}}}
+    with pytest.raises(FormConfigError, match="subform"):
+        validate_forms({"forms": bad})
+
+
+def test_the_shipped_config_validates():
+    """Whatever this deployment ships must pass the check that runs at startup."""
+    from pantograph.config import load_config
+    validate_forms(load_config("config"))
+
+
+def test_a_form_with_no_conditions_compiles_to_nothing():
+    plain = {"elements": {"a": {"type": "string"}}, "meta": {}}
+    assert compile_form("plain", plain) == {}
+
+
+# --------------------------------------------------------------------------
+# What gets stored
+# --------------------------------------------------------------------------
+
+def test_answers_to_questions_that_no_longer_apply_are_cleared():
+    """
+    A record claiming a legitimate-interest balancing test when the basis has
+    since become Consent would be actively misleading. The append-only schema
+    keeps the previous answer in the record's history.
+    """
+    submitted = {
+        "lawful_basis": "consent",
+        "collection_purpose": "left over from an earlier answer",
+        "collection_balance": "also left over",
+        "consent_record": "signed form",
+        "data_categories": ["contact"],
+    }
+    stale = irrelevant_elements(ROPA_FORM, submitted)
+    assert "collection_purpose" in stale and "collection_balance" in stale
+    assert "consent_record" not in stale
+    assert "special_category_safeguards" in stale
+
+
+def test_relevant_answers_are_untouched():
+    submitted = {"lawful_basis": "legitimate_interest",
+                 "collection_purpose": "keep me", "data_categories": []}
+    stale = irrelevant_elements(ROPA_FORM, submitted)
+    assert "collection_purpose" not in stale
+    assert "name" not in stale, "an element with no condition is never stale"
+
+
+# --------------------------------------------------------------------------
+# Wiring
+# --------------------------------------------------------------------------
+
+def test_only_conditional_elements_are_wrapped(monkeypatch):
+    """
+    An element with no `relevant:` must render exactly as before, so nothing
+    about an existing deployment's DOM changes.
+    """
+    monkeypatch.setattr("pantograph.component_factory.get_dropdown_options",
+                        lambda *a, **k: [])
+    layout = generate_form_layout("ropa_form", FORMS)
+    wrapped = _wrapper_ids(layout)
+    assert wrapped == {"collection_purpose", "collection_balance",
+                       "consent_record", "special_category_safeguards"}
+
+
+def _wrapper_ids(component):
+    found = set()
+    cid = getattr(component, "id", None)
+    if isinstance(cid, dict) and cid.get("type") == "relevance":
+        found.add(cid["element"])
+    children = getattr(component, "children", None)
+    if isinstance(children, (list, tuple)):
+        for child in children:
+            found |= _wrapper_ids(child)
+    elif children is not None:
+        found |= _wrapper_ids(children)
+    return found
+
+
+def test_the_callback_watches_only_the_elements_its_conditions_read():
+    """Watching every field would re-run on every keystroke anywhere in the form."""
+    app = Dash(__name__, suppress_callback_exceptions=True)
+    register_relevance_callbacks(app, FORMS)
+
+    # callback_map stores component ids as JSON strings, not dicts.
+    watched = set()
+    outputs = set()
+    for key, cb in app.callback_map.items():
+        for i in cb["inputs"]:
+            cid = json.loads(i["id"]) if isinstance(i["id"], str) else i["id"]
+            if cid.get("type") == "input":
+                watched.add(cid["element"])
+        for part in key.split(".."):
+            if '"type":"relevance"' in part.replace(" ", ""):
+                outputs.add(part)
+
+    assert watched == {"lawful_basis", "data_categories"}
+    assert "name" not in watched
+    assert len(outputs) == 4
+
+
+def test_a_form_without_conditions_registers_no_callback():
+    app = Dash(__name__, suppress_callback_exceptions=True)
+    register_relevance_callbacks(app, {"plain": {"elements": {"a": {"type": "string"}}, "meta": {}}})
+    assert app.callback_map == {}


### PR DESCRIPTION
Closes #58.

An element carrying a `relevant:` expression is shown only when its condition over the answers above it holds. This is the capability the whole records-of-processing plan waits on — "Legitimate Interest makes Purpose, Necessity and Balance mandatory" was not expressible at all, because the core had no conditional logic.

**Adding another conditional field is a config edit. No Python is involved.**

```yaml
lawful_basis:
  type: select_one
  list_name: basis_list
  basis_list: {consent: Consent, legitimate_interest: Legitimate Interest}

collection_purpose:
  type: string
  relevant: "${lawful_basis} = 'legitimate_interest'"
```

Docs: [docs/relevance.md](docs/relevance.md).

## How it works

Two new core modules. [`expressions.py`](src/pantograph/expressions.py) is a tokeniser plus recursive-descent parser producing an AST — **not** Python `eval`. Config is operator-supplied and so nominally trusted, but a form dialect that reaches `eval` is a landmine for whoever later lets a less-trusted user edit config, and the grammar needed is tiny: `${refs}`, `=` `!=` `>` `>=` `<` `<=`, `selected()` for multi-selects, `and`/`or`/`not` with parentheses. Parsing is separate from evaluation so config can be checked at startup.

[`relevance.py`](src/pantograph/relevance.py) holds the three moving parts: startup validation, one callback per form toggling its conditional containers, and submit-time recomputation.

Only elements that carry a condition are wrapped in a container, so a form without conditions renders exactly as before, and a form with them registers exactly one extra callback watching only the elements its conditions actually read.

## Three decisions worth a reviewer's attention

**1. Irrelevant answers are stored as NULL — which contradicts the acceptance criterion I wrote on the issue.** #58 says "hidden fields are not submitted as empty values that overwrite existing data". I implemented the opposite, deliberately: a record claiming a legitimate-interest balancing test when the basis has since been changed to Consent would be actively misleading. It is safe because the schema is append-only and versioned — a new version is written with the field cleared and the previous version still holds the answer. This matches ODK's semantics. Happy to invert it if you disagree; it is a one-line change.

**2. `relevant:` on a subform is rejected at startup rather than silently ignored.** The issue asked for a decision on scope. A subform renders its inputs under its own form namespace, so the enclosing form's callback cannot see their state; supporting it means giving subform state a path back to the parent, which is its own piece of work. Failing loudly beats a condition that never fires.

**3. No production config was changed.** The feature is unused by Collaboratorium today. The natural first application is `contracts_form.organisation_person` — hide the organisation contact until an organisation is chosen — which is what I used for the browser verification. That is a product change, and TODO A's "deliberate decision, not a side effect" argument applies, so I left it out.

## Semantics worth knowing

- **Emptiness is falsehood**, matching the emptiness test the submit button already uses, so "answered" means the same thing to `relevant:` as to `required:`. A bare `${x}` reads as "x has been answered".
- **Numbers compare numerically even when held as strings**, because a `dcc.Input` yields a string even for a field declared as an integer.
- **Multi-select values are accepted both as a list and comma-joined**, because the latter is how they come back from the database — an expression must behave the same on an edit form as on an add form.

## Verification

147 tests pass, up from 87 (60 new). Unit tests prove the logic but not that Dash toggles the DOM, so I also checked in a browser against a config copy: clearing the watched dropdown flipped the dependent field to `display: none` live.

Both failure modes stop startup naming the form, element and cause:

```
FormConfigError: contracts_form.organisation_person: 'relevant' references
  'organisaton', which is not an element of that form.

FormConfigError: contracts_form.organisation_person:
  Unexpected '=' at position 17 in '${organisation} === '
```

Writing `lawful_basis` where you meant `${lawful_basis}` is the likeliest authoring slip, so that error names the fix.

## Knock-on

`compile_form` and the evaluator are exactly what #60 (constraints) needs, and #59 (dynamic `required`) is now unblocked — it is the same evaluation applied to `required` instead of visibility, and it resolves TODO B on the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
